### PR TITLE
Add Turborepo remote cache settings to GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,6 +35,10 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    # Requires GitHub Actions secret `TURBO_TOKEN` and repository variable `TURBO_TEAM`.
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -47,6 +51,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: [typecheck]
+    # Requires GitHub Actions secret `TURBO_TOKEN` and repository variable `TURBO_TEAM`.
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- configure Turborepo remote caching for CI by setting `TURBO_TOKEN` and `TURBO_TEAM` on the `typecheck` and `build` jobs
- document the required GitHub Actions secret and repository variable inline in the workflow
- leave non-Turbo jobs unchanged

## Testing
- Not run (not requested)