### PR TITLE
Add mock-channel app scaffold

### DIFF
--- a/apps/mock-channel/app/globals.css
+++ b/apps/mock-channel/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/apps/mock-channel/app/layout.tsx
+++ b/apps/mock-channel/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+import "./globals.css"
+
+export const metadata: Metadata = {
+	title: "Mock Channel — Amby Dev",
+	description: "Dev-only Telegram channel emulator for local testing",
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+	return (
+		<html lang="en">
+			<body className="bg-neutral-950 text-neutral-100 antialiased">{children}</body>
+		</html>
+	)
+}

--- a/apps/mock-channel/app/page.tsx
+++ b/apps/mock-channel/app/page.tsx
@@ -1,0 +1,10 @@
+export default function Home() {
+	return (
+		<main className="flex h-screen items-center justify-center">
+			<div className="text-center">
+				<h1 className="text-2xl font-bold">Mock Channel</h1>
+				<p className="mt-2 text-neutral-400">Telegram emulator for local development</p>
+			</div>
+		</main>
+	)
+}

--- a/apps/mock-channel/next.config.ts
+++ b/apps/mock-channel/next.config.ts
@@ -1,0 +1,4 @@
+import type { NextConfig } from "next"
+
+const config: NextConfig = {}
+export default config

--- a/apps/mock-channel/package.json
+++ b/apps/mock-channel/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@amby/mock-channel",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev --port 3100",
+		"build": "next build",
+		"typecheck": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome check ."
+	},
+	"dependencies": {
+		"clsx": "^2.1.1",
+		"lucide-react": "^0.577.0",
+		"next": "16",
+		"react": "19",
+		"react-dom": "19",
+		"tailwind-merge": "^3.5.0"
+	},
+	"devDependencies": {
+		"@tailwindcss/postcss": "^4.2.1",
+		"@types/node": "^25.5.0",
+		"@types/react": "^19.2.14",
+		"@types/react-dom": "^19.2.3",
+		"postcss": "^8.5.8",
+		"tailwindcss": "^4.2.1"
+	}
+}

--- a/apps/mock-channel/postcss.config.mjs
+++ b/apps/mock-channel/postcss.config.mjs
@@ -1,0 +1,6 @@
+const config = {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+}
+export default config

--- a/apps/mock-channel/tsconfig.json
+++ b/apps/mock-channel/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"jsx": "preserve",
+		"noEmit": true,
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"incremental": true,
+		"plugins": [{ "name": "next" }],
+		"paths": {
+			"@/*": ["./app/*", "./components/*", "./lib/*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+	"exclude": ["node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,26 @@
         "effect": "^3.21.0",
       },
     },
+    "apps/mock-channel": {
+      "name": "@amby/mock-channel",
+      "version": "0.1.0",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.577.0",
+        "next": "16",
+        "react": "19",
+        "react-dom": "19",
+        "tailwind-merge": "^3.5.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.1",
+        "@types/node": "^25.5.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "postcss": "^8.5.8",
+        "tailwindcss": "^4.2.1",
+      },
+    },
     "apps/web": {
       "name": "@amby/web",
       "version": "0.1.0",
@@ -274,6 +294,8 @@
     "@amby/env": ["@amby/env@workspace:packages/env"],
 
     "@amby/memory": ["@amby/memory@workspace:packages/memory"],
+
+    "@amby/mock-channel": ["@amby/mock-channel@workspace:apps/mock-channel"],
 
     "@amby/web": ["@amby/web@workspace:apps/web"],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 		"tunnel": "doppler run -- ./scripts/tunnel.sh",
 		"docs:notion:pull": "cd docs && doppler run -- notionfs pull",
 		"docs:notion:push": "cd docs && doppler run -- notionfs push",
-		"docs:notion:sync": "cd docs && doppler run -- notionfs sync"
+		"docs:notion:sync": "cd docs && doppler run -- notionfs sync",
+		"mock-channel": "bun run --filter @amby/mock-channel dev"
 	},
 	"packageManager": "bun@1.3.0",
 	"workspaces": [


### PR DESCRIPTION
## Summary
- Create `apps/mock-channel` Next.js 16 + Tailwind 4 app scaffold matching `apps/web` conventions
- Add placeholder layout and page with dark theme styling
- Add `mock-channel` dev script to root `package.json` (runs on port 3100)

## Test plan
- [x] `bun install` links workspace successfully
- [x] `cd apps/mock-channel && bun run build` compiles without errors
- [ ] `bun run mock-channel` starts dev server on port 3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)