### PR TITLE
Add Telegram types and webhook builder for mock-channel

### DIFF
--- a/apps/mock-channel/lib/telegram-types.ts
+++ b/apps/mock-channel/lib/telegram-types.ts
@@ -1,0 +1,69 @@
+export interface TelegramUser {
+	id: number
+	is_bot: boolean
+	first_name: string
+	last_name?: string
+	username?: string
+	language_code?: string
+}
+
+export interface TelegramChat {
+	id: number
+	type: "private" | "group" | "supergroup" | "channel"
+	first_name?: string
+	last_name?: string
+	username?: string
+}
+
+export interface TelegramMessage {
+	message_id: number
+	from?: TelegramUser
+	chat: TelegramChat
+	date: number
+	text?: string
+	entities?: TelegramEntity[]
+}
+
+export interface TelegramEntity {
+	type: string
+	offset: number
+	length: number
+}
+
+export interface TelegramUpdate {
+	update_id: number
+	message?: TelegramMessage
+}
+
+/** Stored message from bot API captures */
+export interface StoredMessage {
+	message_id: number
+	chat_id: number
+	text: string
+	from_bot: boolean
+	date: number
+	edited?: boolean
+	deleted?: boolean
+}
+
+/** Request log entry for debug panel */
+export interface RequestLogEntry {
+	id: string
+	timestamp: number
+	direction: "inbound" | "outbound"
+	method: string
+	url: string
+	body: unknown
+	response?: { status: number; body: unknown }
+}
+
+/** Mock user identity for the chat session */
+export interface MockUserConfig {
+	telegramUserId: number
+	firstName: string
+	lastName?: string
+	username?: string
+	chatId: number
+	backendUrl: string
+	webhookSecret: string
+}

--- a/apps/mock-channel/lib/webhook-builder.test.ts
+++ b/apps/mock-channel/lib/webhook-builder.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach } from "bun:test"
+import { buildTelegramUpdate, resetCounters } from "./webhook-builder"
+import type { MockUserConfig } from "./telegram-types"
+
+const mockUser: MockUserConfig = {
+	telegramUserId: 12345,
+	firstName: "Test",
+	lastName: "User",
+	username: "testuser",
+	chatId: 67890,
+	backendUrl: "http://localhost:3001",
+	webhookSecret: "test-secret",
+}
+
+describe("buildTelegramUpdate", () => {
+	beforeEach(() => resetCounters())
+
+	it("produces a valid TelegramUpdate shape", () => {
+		const update = buildTelegramUpdate({ text: "hello", user: mockUser })
+		expect(update.update_id).toBeGreaterThan(0)
+		expect(update.message).toBeDefined()
+		expect(update.message!.text).toBe("hello")
+		expect(update.message!.from?.id).toBe(12345)
+		expect(update.message!.chat.id).toBe(67890)
+		expect(update.message!.chat.type).toBe("private")
+	})
+
+	it("increments update_id and message_id on successive calls", () => {
+		const first = buildTelegramUpdate({ text: "a", user: mockUser })
+		const second = buildTelegramUpdate({ text: "b", user: mockUser })
+		expect(second.update_id).toBe(first.update_id + 1)
+		expect(second.message!.message_id).toBe(first.message!.message_id + 1)
+	})
+
+	it("sets date to current Unix timestamp", () => {
+		const before = Math.floor(Date.now() / 1000)
+		const update = buildTelegramUpdate({ text: "test", user: mockUser })
+		const after = Math.floor(Date.now() / 1000)
+		expect(update.message!.date).toBeGreaterThanOrEqual(before)
+		expect(update.message!.date).toBeLessThanOrEqual(after)
+	})
+
+	it("includes user identity fields", () => {
+		const update = buildTelegramUpdate({ text: "hi", user: mockUser })
+		const from = update.message!.from!
+		expect(from.first_name).toBe("Test")
+		expect(from.last_name).toBe("User")
+		expect(from.username).toBe("testuser")
+		expect(from.is_bot).toBe(false)
+		expect(from.language_code).toBe("en")
+	})
+
+	it("works without optional user fields", () => {
+		const minimalUser: MockUserConfig = {
+			telegramUserId: 99,
+			firstName: "Min",
+			chatId: 100,
+			backendUrl: "http://localhost:3001",
+			webhookSecret: "s",
+		}
+		const update = buildTelegramUpdate({ text: "test", user: minimalUser })
+		expect(update.message!.from?.first_name).toBe("Min")
+		expect(update.message!.from?.last_name).toBeUndefined()
+	})
+})

--- a/apps/mock-channel/lib/webhook-builder.ts
+++ b/apps/mock-channel/lib/webhook-builder.ts
@@ -1,0 +1,41 @@
+import type { TelegramUpdate, MockUserConfig } from "./telegram-types"
+
+let nextUpdateId = 100000
+let nextMessageId = 1
+
+export function buildTelegramUpdate(params: {
+	text: string
+	user: MockUserConfig
+}): TelegramUpdate {
+	const updateId = nextUpdateId++
+	const messageId = nextMessageId++
+
+	return {
+		update_id: updateId,
+		message: {
+			message_id: messageId,
+			from: {
+				id: params.user.telegramUserId,
+				is_bot: false,
+				first_name: params.user.firstName,
+				last_name: params.user.lastName,
+				username: params.user.username,
+				language_code: "en",
+			},
+			chat: {
+				id: params.user.chatId,
+				type: "private",
+				first_name: params.user.firstName,
+				last_name: params.user.lastName,
+				username: params.user.username,
+			},
+			date: Math.floor(Date.now() / 1000),
+			text: params.text,
+		},
+	}
+}
+
+export function resetCounters() {
+	nextUpdateId = 100000
+	nextMessageId = 1
+}

--- a/apps/mock-channel/package.json
+++ b/apps/mock-channel/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@amby/mock-channel",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"test": "bun test"
+	},
+	"devDependencies": {
+		"bun-types": "^1.3.10"
+	}
+}

--- a/apps/mock-channel/tsconfig.json
+++ b/apps/mock-channel/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"types": ["bun-types"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"outDir": "dist"
+	},
+	"include": ["lib/**/*.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,13 @@
         "effect": "^3.21.0",
       },
     },
+    "apps/mock-channel": {
+      "name": "@amby/mock-channel",
+      "version": "0.1.0",
+      "devDependencies": {
+        "bun-types": "^1.3.10",
+      },
+    },
     "apps/web": {
       "name": "@amby/web",
       "version": "0.1.0",
@@ -274,6 +281,8 @@
     "@amby/env": ["@amby/env@workspace:packages/env"],
 
     "@amby/memory": ["@amby/memory@workspace:packages/memory"],
+
+    "@amby/mock-channel": ["@amby/mock-channel@workspace:apps/mock-channel"],
 
     "@amby/web": ["@amby/web@workspace:apps/web"],
 


### PR DESCRIPTION
## Summary
- Add self-contained Telegram API type definitions (`TelegramUser`, `TelegramChat`, `TelegramMessage`, `TelegramUpdate`, etc.) for the mock-channel app
- Add `buildTelegramUpdate` webhook payload builder that constructs realistic Telegram update payloads with auto-incrementing IDs
- Add full test coverage (5 tests) using `bun:test`
- Scaffold minimal `package.json` and `tsconfig.json` for the mock-channel package

## Test plan
- [x] All 5 unit tests pass (`bun test` -- 0 failures)
- [x] Tests cover: valid shape, incrementing IDs, timestamp accuracy, user identity fields, optional fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)