### PR TITLE
Add mock-channel message store, SSE emitter, and config

### DIFF
--- a/apps/mock-channel/lib/config.ts
+++ b/apps/mock-channel/lib/config.ts
@@ -1,0 +1,25 @@
+import type { MockUserConfig } from "./telegram-types"
+
+export function getDefaultMockUser(): MockUserConfig {
+	return {
+		telegramUserId: 99001,
+		firstName: "Dev",
+		lastName: "Tester",
+		username: "devtester",
+		chatId: 99001,
+		backendUrl: getBackendUrl(),
+		webhookSecret: getWebhookSecret(),
+	}
+}
+
+export function getBackendUrl(): string {
+	return process.env.BACKEND_URL || "http://localhost:3001"
+}
+
+export function getWebhookSecret(): string {
+	return process.env.TELEGRAM_WEBHOOK_SECRET || "dev-secret"
+}
+
+export function getBotToken(): string {
+	return process.env.TELEGRAM_BOT_TOKEN || "dev-mock-token"
+}

--- a/apps/mock-channel/lib/message-store.test.ts
+++ b/apps/mock-channel/lib/message-store.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, beforeEach } from "bun:test"
+import {
+	addMessage,
+	editMessage,
+	deleteMessage,
+	getMessages,
+	addLogEntry,
+	getRequestLog,
+	clearStore,
+} from "./message-store"
+
+describe("message store", () => {
+	beforeEach(() => clearStore())
+
+	it("adds messages with incrementing IDs", () => {
+		const m1 = addMessage({ chat_id: 1, text: "hello", from_bot: true, date: 123 })
+		const m2 = addMessage({ chat_id: 1, text: "world", from_bot: true, date: 124 })
+		expect(m2.message_id).toBe(m1.message_id + 1)
+	})
+
+	it("returns non-deleted messages", () => {
+		addMessage({ chat_id: 1, text: "keep", from_bot: true, date: 1 })
+		const m2 = addMessage({ chat_id: 1, text: "remove", from_bot: true, date: 2 })
+		deleteMessage(m2.message_id)
+		const msgs = getMessages()
+		expect(msgs).toHaveLength(1)
+		expect(msgs[0]?.text).toBe("keep")
+	})
+
+	it("edits existing messages", () => {
+		const msg = addMessage({ chat_id: 1, text: "original", from_bot: true, date: 1 })
+		const edited = editMessage(msg.message_id, "updated")
+		expect(edited?.text).toBe("updated")
+		expect(edited?.edited).toBe(true)
+	})
+
+	it("returns null when editing non-existent message", () => {
+		expect(editMessage(99999, "nope")).toBeNull()
+	})
+
+	it("tracks request log entries", () => {
+		addLogEntry({ direction: "outbound", method: "POST", url: "/test", body: {} })
+		expect(getRequestLog()).toHaveLength(1)
+	})
+
+	it("clears all state", () => {
+		addMessage({ chat_id: 1, text: "test", from_bot: true, date: 1 })
+		addLogEntry({ direction: "outbound", method: "POST", url: "/test", body: {} })
+		clearStore()
+		expect(getMessages()).toHaveLength(0)
+		expect(getRequestLog()).toHaveLength(0)
+	})
+})

--- a/apps/mock-channel/lib/message-store.ts
+++ b/apps/mock-channel/lib/message-store.ts
@@ -1,0 +1,82 @@
+import type { StoredMessage, RequestLogEntry } from "./telegram-types"
+
+interface MessageStore {
+	messages: Map<number, StoredMessage>
+	requestLog: RequestLogEntry[]
+	nextMessageId: number
+}
+
+const MAX_LOG_ENTRIES = 100
+
+function createStore(): MessageStore {
+	return {
+		messages: new Map(),
+		requestLog: [],
+		nextMessageId: 1000,
+	}
+}
+
+// Persist across HMR in development
+const globalStore = globalThis as unknown as { __mockChannelStore?: MessageStore }
+
+export function getStore(): MessageStore {
+	if (!globalStore.__mockChannelStore) {
+		globalStore.__mockChannelStore = createStore()
+	}
+	return globalStore.__mockChannelStore
+}
+
+export function addMessage(msg: Omit<StoredMessage, "message_id">): StoredMessage {
+	const store = getStore()
+	const message_id = store.nextMessageId++
+	const stored: StoredMessage = { ...msg, message_id }
+	store.messages.set(message_id, stored)
+	return stored
+}
+
+export function editMessage(messageId: number, text: string): StoredMessage | null {
+	const store = getStore()
+	const msg = store.messages.get(messageId)
+	if (!msg) return null
+	msg.text = text
+	msg.edited = true
+	return msg
+}
+
+export function deleteMessage(messageId: number): boolean {
+	const store = getStore()
+	const msg = store.messages.get(messageId)
+	if (!msg) return false
+	msg.deleted = true
+	return true
+}
+
+export function getMessages(): StoredMessage[] {
+	const store = getStore()
+	return [...store.messages.values()].filter((m) => !m.deleted)
+}
+
+export function addLogEntry(entry: Omit<RequestLogEntry, "id" | "timestamp">): RequestLogEntry {
+	const store = getStore()
+	const logged: RequestLogEntry = {
+		...entry,
+		id: crypto.randomUUID(),
+		timestamp: Date.now(),
+	}
+	store.requestLog.push(logged)
+	if (store.requestLog.length > MAX_LOG_ENTRIES) {
+		store.requestLog = store.requestLog.slice(-MAX_LOG_ENTRIES)
+	}
+	return logged
+}
+
+export function getRequestLog(): RequestLogEntry[] {
+	return getStore().requestLog
+}
+
+export function clearStore(): void {
+	const store = getStore()
+	store.messages.clear()
+	store.requestLog = []
+	store.nextMessageId = 1000
+}

--- a/apps/mock-channel/lib/sse-emitter.ts
+++ b/apps/mock-channel/lib/sse-emitter.ts
@@ -1,0 +1,38 @@
+export type SSECallback = (event: string, data: string) => void
+
+export interface SSEEmitter {
+	subscribe(callback: SSECallback): () => void
+	broadcast(event: string, data: unknown): void
+}
+
+function createEmitter(): SSEEmitter {
+	const listeners = new Set<SSECallback>()
+
+	return {
+		subscribe(callback: SSECallback): () => void {
+			listeners.add(callback)
+			return () => listeners.delete(callback)
+		},
+		broadcast(event: string, data: unknown): void {
+			const json = JSON.stringify(data)
+			for (const listener of listeners) {
+				try {
+					listener(event, json)
+				} catch {
+					// Remove dead listeners
+					listeners.delete(listener)
+				}
+			}
+		},
+	}
+}
+
+// Persist across HMR
+const globalEmitter = globalThis as unknown as { __mockChannelEmitter?: SSEEmitter }
+
+export function getEmitter(): SSEEmitter {
+	if (!globalEmitter.__mockChannelEmitter) {
+		globalEmitter.__mockChannelEmitter = createEmitter()
+	}
+	return globalEmitter.__mockChannelEmitter
+}

--- a/apps/mock-channel/lib/telegram-types.ts
+++ b/apps/mock-channel/lib/telegram-types.ts
@@ -1,0 +1,29 @@
+export interface StoredMessage {
+	message_id: number
+	chat_id: number
+	text: string
+	from_bot: boolean
+	date: number
+	edited?: boolean
+	deleted?: boolean
+}
+
+export interface RequestLogEntry {
+	id: string
+	timestamp: number
+	direction: "inbound" | "outbound"
+	method: string
+	url: string
+	body: unknown
+	response?: { status: number; body: unknown }
+}
+
+export interface MockUserConfig {
+	telegramUserId: number
+	firstName: string
+	lastName?: string
+	username?: string
+	chatId: number
+	backendUrl: string
+	webhookSecret: string
+}

--- a/apps/mock-channel/package.json
+++ b/apps/mock-channel/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@amby/mock-channel",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"test": "bun test"
+	},
+	"devDependencies": {
+		"bun-types": "^1.3.10"
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,13 @@
         "effect": "^3.21.0",
       },
     },
+    "apps/mock-channel": {
+      "name": "@amby/mock-channel",
+      "version": "0.1.0",
+      "devDependencies": {
+        "bun-types": "^1.3.10",
+      },
+    },
     "apps/web": {
       "name": "@amby/web",
       "version": "0.1.0",
@@ -274,6 +281,8 @@
     "@amby/env": ["@amby/env@workspace:packages/env"],
 
     "@amby/memory": ["@amby/memory@workspace:packages/memory"],
+
+    "@amby/mock-channel": ["@amby/mock-channel@workspace:apps/mock-channel"],
 
     "@amby/web": ["@amby/web@workspace:apps/web"],
 


### PR DESCRIPTION
## Summary
- Add `apps/mock-channel` package with server-side singletons for the dev-only mock Telegram channel
- **telegram-types.ts**: Shared type definitions (StoredMessage, RequestLogEntry, MockUserConfig)
- **message-store.ts**: HMR-persistent in-memory store for messages and request logs with add/edit/delete/clear operations
- **sse-emitter.ts**: Pub/sub broadcaster for real-time SSE connections to the UI
- **config.ts**: Environment variable helpers with sensible dev defaults (lazy evaluation to avoid stale module-load values)
- **message-store.test.ts**: 6 unit tests covering all store operations

## Test plan
- [x] `bun test` passes (6/6 tests)
- [ ] Verify types are consumed correctly by downstream units (API routes, UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)