### PR TITLE
Add webhook proxy and SSE events for mock Telegram channel

### DIFF
--- a/apps/mock-channel/app/api/clear/route.ts
+++ b/apps/mock-channel/app/api/clear/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server"
+import { clearStore } from "../../../lib/message-store"
+import { getEmitter } from "../../../lib/sse-emitter"
+
+export async function POST() {
+	clearStore()
+	getEmitter().broadcast("clear", {})
+	return NextResponse.json({ ok: true })
+}

--- a/apps/mock-channel/app/api/events/route.ts
+++ b/apps/mock-channel/app/api/events/route.ts
@@ -1,0 +1,40 @@
+import { getEmitter } from "../../../lib/sse-emitter"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+	const emitter = getEmitter()
+
+	let unsubscribe: (() => void) | undefined
+
+	const stream = new ReadableStream({
+		start(controller) {
+			const encoder = new TextEncoder()
+
+			const send = (event: string, data: string) => {
+				try {
+					controller.enqueue(
+						encoder.encode(`event: ${event}\ndata: ${data}\n\n`),
+					)
+				} catch {
+					unsubscribe?.()
+				}
+			}
+
+			send("ping", JSON.stringify({ time: Date.now() }))
+
+			unsubscribe = emitter.subscribe(send)
+		},
+		cancel() {
+			unsubscribe?.()
+		},
+	})
+
+	return new Response(stream, {
+		headers: {
+			"Content-Type": "text/event-stream",
+			"Cache-Control": "no-cache, no-transform",
+			Connection: "keep-alive",
+		},
+	})
+}

--- a/apps/mock-channel/app/api/send/route.ts
+++ b/apps/mock-channel/app/api/send/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server"
+import { buildTelegramUpdate } from "../../../lib/webhook-builder"
+import { addMessage, addLogEntry } from "../../../lib/message-store"
+import { getBackendUrl, getWebhookSecret } from "../../../lib/config"
+import type { MockUserConfig } from "../../../lib/telegram-types"
+
+export async function POST(request: NextRequest) {
+	const body = (await request.json()) as {
+		text: string
+		user: MockUserConfig
+	}
+
+	const { text, user } = body
+	const trimmed = text?.trim()
+	if (!trimmed) {
+		return NextResponse.json({ error: "text is required" }, { status: 400 })
+	}
+
+	const update = buildTelegramUpdate({ text: trimmed, user })
+
+	addMessage({
+		chat_id: user.chatId,
+		text: trimmed,
+		from_bot: false,
+		date: Math.floor(Date.now() / 1000),
+	})
+
+	const backendUrl = user.backendUrl || getBackendUrl()
+	const webhookSecret = user.webhookSecret || getWebhookSecret()
+	const webhookUrl = `${backendUrl}/telegram/webhook`
+
+	const logEntry = addLogEntry({
+		direction: "inbound",
+		method: "POST",
+		url: webhookUrl,
+		body: update,
+	})
+
+	try {
+		const response = await fetch(webhookUrl, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-telegram-bot-api-secret-token": webhookSecret,
+			},
+			body: JSON.stringify(update),
+		})
+
+		const responseBody = await response.text()
+
+		logEntry.response = {
+			status: response.status,
+			body: responseBody,
+		}
+
+		return NextResponse.json({
+			ok: true,
+			webhookStatus: response.status,
+			update,
+		})
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+
+		logEntry.response = {
+			status: 0,
+			body: { error: message },
+		}
+
+		return NextResponse.json(
+			{ ok: false, error: `Failed to reach backend: ${message}` },
+			{ status: 502 },
+		)
+	}
+}

--- a/apps/mock-channel/app/api/state/route.ts
+++ b/apps/mock-channel/app/api/state/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server"
+import { getMessages, getRequestLog } from "../../../lib/message-store"
+
+export async function GET() {
+	return NextResponse.json({
+		messages: getMessages(),
+		requestLog: getRequestLog(),
+	})
+}

--- a/apps/mock-channel/lib/config.ts
+++ b/apps/mock-channel/lib/config.ts
@@ -1,0 +1,11 @@
+export function getBackendUrl(): string {
+	return process.env.MOCK_BACKEND_URL ?? "http://localhost:3001"
+}
+
+export function getWebhookSecret(): string {
+	return process.env.MOCK_WEBHOOK_SECRET ?? "mock-secret"
+}
+
+export function getBotToken(): string {
+	return process.env.MOCK_BOT_TOKEN ?? "000000000:MOCK-TOKEN"
+}

--- a/apps/mock-channel/lib/message-store.ts
+++ b/apps/mock-channel/lib/message-store.ts
@@ -1,0 +1,61 @@
+import type { RequestLogEntry, StoredMessage } from "./telegram-types"
+
+let nextMessageId = 1
+
+const messages: StoredMessage[] = []
+const requestLog: RequestLogEntry[] = []
+
+export function addMessage(params: {
+	chat_id: number
+	text: string
+	from_bot: boolean
+	date: number
+}): StoredMessage {
+	const msg: StoredMessage = {
+		message_id: nextMessageId++,
+		chat_id: params.chat_id,
+		text: params.text,
+		from_bot: params.from_bot,
+		date: params.date,
+	}
+	messages.push(msg)
+	return msg
+}
+
+export function addLogEntry(params: {
+	direction: "inbound" | "outbound"
+	method: string
+	url: string
+	body: unknown
+}): RequestLogEntry {
+	const entry: RequestLogEntry = {
+		id: crypto.randomUUID(),
+		timestamp: Date.now(),
+		direction: params.direction,
+		method: params.method,
+		url: params.url,
+		body: params.body,
+	}
+	requestLog.push(entry)
+	return entry
+}
+
+export function getMessages(): StoredMessage[] {
+	return [...messages]
+}
+
+export function getRequestLog(): RequestLogEntry[] {
+	return [...requestLog]
+}
+
+export function getStore() {
+	return {
+		messages: getMessages(),
+		requestLog: getRequestLog(),
+	}
+}
+
+export function clearStore(): void {
+	messages.length = 0
+	requestLog.length = 0
+}

--- a/apps/mock-channel/lib/sse-emitter.ts
+++ b/apps/mock-channel/lib/sse-emitter.ts
@@ -1,0 +1,34 @@
+type Listener = (event: string, data: string) => void
+
+interface SseEmitter {
+	subscribe: (listener: Listener) => () => void
+	broadcast: (event: string, data: unknown) => void
+}
+
+let emitter: SseEmitter | null = null
+
+function createEmitter(): SseEmitter {
+	const listeners = new Set<Listener>()
+
+	return {
+		subscribe(listener: Listener) {
+			listeners.add(listener)
+			return () => {
+				listeners.delete(listener)
+			}
+		},
+		broadcast(event: string, data: unknown) {
+			const payload = JSON.stringify(data)
+			for (const listener of listeners) {
+				listener(event, payload)
+			}
+		},
+	}
+}
+
+export function getEmitter(): SseEmitter {
+	if (!emitter) {
+		emitter = createEmitter()
+	}
+	return emitter
+}

--- a/apps/mock-channel/lib/telegram-types.ts
+++ b/apps/mock-channel/lib/telegram-types.ts
@@ -1,0 +1,59 @@
+export interface TelegramUser {
+	id: number
+	is_bot: boolean
+	first_name: string
+	last_name?: string
+	username?: string
+	language_code?: string
+}
+
+export interface TelegramChat {
+	id: number
+	type: "private" | "group" | "supergroup" | "channel"
+	first_name?: string
+	last_name?: string
+	username?: string
+}
+
+export interface TelegramMessage {
+	message_id: number
+	from?: TelegramUser
+	chat: TelegramChat
+	date: number
+	text?: string
+}
+
+export interface TelegramUpdate {
+	update_id: number
+	message?: TelegramMessage
+}
+
+export interface StoredMessage {
+	message_id: number
+	chat_id: number
+	text: string
+	from_bot: boolean
+	date: number
+	edited?: boolean
+	deleted?: boolean
+}
+
+export interface RequestLogEntry {
+	id: string
+	timestamp: number
+	direction: "inbound" | "outbound"
+	method: string
+	url: string
+	body: unknown
+	response?: { status: number; body: unknown }
+}
+
+export interface MockUserConfig {
+	telegramUserId: number
+	firstName: string
+	lastName?: string
+	username?: string
+	chatId: number
+	backendUrl: string
+	webhookSecret: string
+}

--- a/apps/mock-channel/lib/webhook-builder.ts
+++ b/apps/mock-channel/lib/webhook-builder.ts
@@ -1,0 +1,46 @@
+import type {
+	MockUserConfig,
+	TelegramChat,
+	TelegramUpdate,
+	TelegramUser,
+} from "./telegram-types"
+
+let nextUpdateId = 1
+let nextMessageId = 1
+
+export function buildTelegramUpdate(params: {
+	text: string
+	user: MockUserConfig
+}): TelegramUpdate {
+	const { text, user } = params
+
+	const from: TelegramUser = {
+		id: user.telegramUserId,
+		is_bot: false,
+		first_name: user.firstName,
+		last_name: user.lastName,
+		username: user.username,
+		language_code: "en",
+	}
+
+	const chat: TelegramChat = {
+		id: user.chatId,
+		type: "private",
+		first_name: user.firstName,
+		last_name: user.lastName,
+		username: user.username,
+	}
+
+	const update: TelegramUpdate = {
+		update_id: nextUpdateId++,
+		message: {
+			message_id: nextMessageId++,
+			from,
+			chat,
+			date: Math.floor(Date.now() / 1000),
+			text,
+		},
+	}
+
+	return update
+}

--- a/apps/mock-channel/package.json
+++ b/apps/mock-channel/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@amby/mock-channel",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev --port 3100",
+		"build": "next build",
+		"start": "next start --port 3100",
+		"typecheck": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome check .",
+		"lint:fix": "bunx @biomejs/biome check --fix ."
+	},
+	"dependencies": {
+		"next": "^15.3.2",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.15.3",
+		"@types/react": "^19.1.2",
+		"typescript": "^5.8.3"
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/send` route that builds a Telegram webhook update from user input and proxies it to the backend, avoiding CORS issues
- Adds `GET /api/events` SSE endpoint that streams bot responses and state changes to the browser in real-time
- Adds `GET /api/state` and `POST /api/clear` debug/reset endpoints
- Creates supporting library modules: telegram-types, webhook-builder, message-store, sse-emitter, and config

## Test plan
- [ ] Verify POST /api/send returns 400 for empty text
- [ ] Verify POST /api/send builds correct Telegram update shape and forwards to backend
- [ ] Verify POST /api/send returns 502 when backend is unreachable
- [ ] Verify GET /api/events opens SSE stream and receives initial ping
- [ ] Verify SSE broadcast delivers events to connected clients
- [ ] Verify POST /api/clear resets store and emits clear event via SSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)