### PR TITLE
Add mock Telegram Bot API server

### DIFF
--- a/apps/mock-channel/app/api/mock-bot/[...path]/route.ts
+++ b/apps/mock-channel/app/api/mock-bot/[...path]/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+	addMessage,
+	editMessage,
+	deleteMessage,
+	addLogEntry,
+} from "../../../../lib/message-store"
+import { getEmitter } from "../../../../lib/sse-emitter"
+
+export async function POST(
+	request: NextRequest,
+	{ params }: { params: Promise<{ path: string[] }> },
+) {
+	const segments = (await params).path
+	const method = segments.slice(1).join("/")
+
+	let body: Record<string, unknown> = {}
+	const contentType = request.headers.get("content-type") || ""
+	if (contentType.includes("application/json")) {
+		body = await request.json()
+	} else if (contentType.includes("multipart/form-data")) {
+		const formData = await request.formData()
+		for (const [key, value] of formData.entries()) {
+			body[key] = typeof value === "string" ? value : value.name
+		}
+	}
+
+	addLogEntry({
+		direction: "outbound",
+		method: "POST",
+		url: `/api/mock-bot/${segments.join("/")}`,
+		body,
+	})
+
+	const emitter = getEmitter()
+	const chatId = Number(body.chat_id) || 0
+	const botFrom = {
+		id: 1,
+		is_bot: true,
+		first_name: "Amby",
+		username: "amby_bot",
+	} as const
+
+	switch (method) {
+		case "sendMessage": {
+			const text = String(body.text || "")
+			const msg = addMessage({
+				chat_id: chatId,
+				text,
+				from_bot: true,
+				date: Math.floor(Date.now() / 1000),
+			})
+			emitter.broadcast("message", msg)
+			return NextResponse.json({
+				ok: true,
+				result: {
+					message_id: msg.message_id,
+					from: botFrom,
+					chat: { id: chatId, type: "private" },
+					date: msg.date,
+					text: msg.text,
+				},
+			})
+		}
+
+		case "editMessageText": {
+			const messageId = Number(body.message_id) || 0
+			const text = String(body.text || "")
+			const edited = editMessage(messageId, text)
+			if (edited) {
+				emitter.broadcast("edit", edited)
+			}
+			const now = Math.floor(Date.now() / 1000)
+			return NextResponse.json({
+				ok: true,
+				result: {
+					message_id: messageId,
+					from: botFrom,
+					chat: { id: chatId, type: "private" },
+					date: now,
+					text,
+					edit_date: now,
+				},
+			})
+		}
+
+		case "deleteMessage": {
+			const messageId = Number(body.message_id) || 0
+			deleteMessage(messageId)
+			emitter.broadcast("delete", { message_id: messageId, chat_id: chatId })
+			return NextResponse.json({ ok: true, result: true })
+		}
+
+		case "sendChatAction": {
+			emitter.broadcast("typing", {
+				chat_id: chatId,
+				action: body.action,
+			})
+			return NextResponse.json({ ok: true, result: true })
+		}
+
+		case "setMyCommands":
+			return NextResponse.json({ ok: true, result: true })
+
+		case "getMe":
+			return NextResponse.json({
+				ok: true,
+				result: {
+					...botFrom,
+					can_join_groups: true,
+					can_read_all_group_messages: false,
+					supports_inline_queries: false,
+				},
+			})
+
+		default:
+			console.log(`[mock-bot] Unhandled method: ${method}`, body)
+			return NextResponse.json({ ok: true, result: {} })
+	}
+}

--- a/apps/mock-channel/app/api/mock-bot/mock-bot.test.ts
+++ b/apps/mock-channel/app/api/mock-bot/mock-bot.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, beforeEach } from "bun:test"
+import {
+	addMessage,
+	editMessage,
+	deleteMessage,
+	getMessages,
+	clearStore,
+} from "../../../lib/message-store"
+import { getEmitter } from "../../../lib/sse-emitter"
+
+describe("mock bot API logic", () => {
+	beforeEach(() => clearStore())
+
+	it("sendMessage adds a bot message and returns it", () => {
+		const msg = addMessage({
+			chat_id: 42,
+			text: "Hello from bot",
+			from_bot: true,
+			date: 1000,
+		})
+		expect(msg.message_id).toBe(1)
+		expect(msg.chat_id).toBe(42)
+		expect(msg.text).toBe("Hello from bot")
+		expect(msg.from_bot).toBe(true)
+	})
+
+	it("editMessageText updates an existing message", () => {
+		const msg = addMessage({
+			chat_id: 42,
+			text: "Original",
+			from_bot: true,
+			date: 1000,
+		})
+		const edited = editMessage(msg.message_id, "Updated text")
+		expect(edited).not.toBeNull()
+		expect(edited!.text).toBe("Updated text")
+		expect(edited!.edit_date).toBeDefined()
+	})
+
+	it("editMessageText returns null for unknown message", () => {
+		const edited = editMessage(999, "No such message")
+		expect(edited).toBeNull()
+	})
+
+	it("deleteMessage removes the message from the store", () => {
+		const msg = addMessage({
+			chat_id: 42,
+			text: "To delete",
+			from_bot: true,
+			date: 1000,
+		})
+		expect(getMessages()).toHaveLength(1)
+		const deleted = deleteMessage(msg.message_id)
+		expect(deleted).toBe(true)
+		expect(getMessages()).toHaveLength(0)
+	})
+
+	it("deleteMessage returns false for unknown message", () => {
+		expect(deleteMessage(999)).toBe(false)
+	})
+
+	it("emitter broadcasts events to subscribers", () => {
+		const emitter = getEmitter()
+		const received: { event: string; data: unknown }[] = []
+		const unsub = emitter.subscribe((event, data) => {
+			received.push({ event, data })
+		})
+
+		emitter.broadcast("message", { text: "test" })
+		expect(received).toHaveLength(1)
+		expect(received[0]!.event).toBe("message")
+
+		unsub()
+		emitter.broadcast("message", { text: "after unsub" })
+		expect(received).toHaveLength(1)
+	})
+
+	it("sendMessage response matches Telegram format", () => {
+		const msg = addMessage({
+			chat_id: 42,
+			text: "Hello",
+			from_bot: true,
+			date: 1000,
+		})
+		const response = {
+			ok: true,
+			result: {
+				message_id: msg.message_id,
+				from: {
+					id: 1,
+					is_bot: true,
+					first_name: "Amby",
+					username: "amby_bot",
+				},
+				chat: { id: 42, type: "private" },
+				date: msg.date,
+				text: msg.text,
+			},
+		}
+		expect(response.ok).toBe(true)
+		expect(response.result.from.is_bot).toBe(true)
+		expect(response.result.message_id).toBeGreaterThan(0)
+		expect(response.result.chat.type).toBe("private")
+	})
+
+	it("assigns incrementing message IDs", () => {
+		const m1 = addMessage({
+			chat_id: 1,
+			text: "First",
+			from_bot: true,
+			date: 1000,
+		})
+		const m2 = addMessage({
+			chat_id: 1,
+			text: "Second",
+			from_bot: true,
+			date: 1001,
+		})
+		expect(m2.message_id).toBe(m1.message_id + 1)
+	})
+})

--- a/apps/mock-channel/lib/message-store.ts
+++ b/apps/mock-channel/lib/message-store.ts
@@ -1,0 +1,78 @@
+import type { StoredMessage, RequestLogEntry, MessageStore } from "./telegram-types"
+
+declare const globalThis: {
+	__mockChannelStore?: MessageStore
+}
+
+function getStore(): MessageStore {
+	if (!globalThis.__mockChannelStore) {
+		globalThis.__mockChannelStore = {
+			messages: [],
+			log: [],
+			nextMessageId: 1,
+			nextLogId: 1,
+		}
+	}
+	return globalThis.__mockChannelStore
+}
+
+export function addMessage(
+	input: Omit<StoredMessage, "message_id">,
+): StoredMessage {
+	const store = getStore()
+	const msg: StoredMessage = {
+		...input,
+		message_id: store.nextMessageId++,
+	}
+	store.messages.push(msg)
+	return msg
+}
+
+export function editMessage(
+	messageId: number,
+	text: string,
+): StoredMessage | null {
+	const store = getStore()
+	const msg = store.messages.find((m) => m.message_id === messageId)
+	if (!msg) return null
+	msg.text = text
+	msg.edit_date = Math.floor(Date.now() / 1000)
+	return msg
+}
+
+export function deleteMessage(messageId: number): boolean {
+	const store = getStore()
+	const index = store.messages.findIndex((m) => m.message_id === messageId)
+	if (index === -1) return false
+	store.messages.splice(index, 1)
+	return true
+}
+
+export function addLogEntry(
+	input: Omit<RequestLogEntry, "id" | "timestamp">,
+): RequestLogEntry {
+	const store = getStore()
+	const entry: RequestLogEntry = {
+		...input,
+		id: store.nextLogId++,
+		timestamp: Date.now(),
+	}
+	store.log.push(entry)
+	return entry
+}
+
+export function getMessages(): StoredMessage[] {
+	return getStore().messages
+}
+
+export function getLog(): RequestLogEntry[] {
+	return getStore().log
+}
+
+export function clearStore(): void {
+	const store = getStore()
+	store.messages = []
+	store.log = []
+	store.nextMessageId = 1
+	store.nextLogId = 1
+}

--- a/apps/mock-channel/lib/sse-emitter.ts
+++ b/apps/mock-channel/lib/sse-emitter.ts
@@ -1,0 +1,35 @@
+type Listener = (event: string, data: unknown) => void
+
+interface Emitter {
+	subscribe: (listener: Listener) => () => void
+	broadcast: (event: string, data: unknown) => void
+}
+
+declare const globalThis: {
+	__mockChannelEmitter?: Emitter
+}
+
+function createEmitter(): Emitter {
+	const listeners = new Set<Listener>()
+
+	return {
+		subscribe(listener: Listener) {
+			listeners.add(listener)
+			return () => {
+				listeners.delete(listener)
+			}
+		},
+		broadcast(event: string, data: unknown) {
+			for (const listener of listeners) {
+				listener(event, data)
+			}
+		},
+	}
+}
+
+export function getEmitter(): Emitter {
+	if (!globalThis.__mockChannelEmitter) {
+		globalThis.__mockChannelEmitter = createEmitter()
+	}
+	return globalThis.__mockChannelEmitter
+}

--- a/apps/mock-channel/lib/telegram-types.ts
+++ b/apps/mock-channel/lib/telegram-types.ts
@@ -1,0 +1,24 @@
+export interface StoredMessage {
+	message_id: number
+	chat_id: number
+	text: string
+	from_bot: boolean
+	date: number
+	edit_date?: number
+}
+
+export interface RequestLogEntry {
+	id: number
+	timestamp: number
+	direction: "inbound" | "outbound"
+	method: string
+	url: string
+	body: Record<string, unknown>
+}
+
+export interface MessageStore {
+	messages: StoredMessage[]
+	log: RequestLogEntry[]
+	nextMessageId: number
+	nextLogId: number
+}

--- a/apps/mock-channel/package.json
+++ b/apps/mock-channel/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@amby/mock-channel",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev --port 3100",
+		"build": "next build",
+		"start": "next start --port 3100",
+		"test": "bun test",
+		"typecheck": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome check .",
+		"lint:fix": "bunx @biomejs/biome check --fix .",
+		"format": "bunx @biomejs/biome format --write ."
+	},
+	"dependencies": {
+		"next": "16",
+		"react": "19",
+		"react-dom": "19"
+	},
+	"devDependencies": {
+		"@types/node": "^25.5.0",
+		"@types/react": "^19.2.14",
+		"@types/react-dom": "^19.2.3",
+		"bun-types": "latest"
+	}
+}

--- a/apps/mock-channel/tsconfig.json
+++ b/apps/mock-channel/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["dom", "dom.iterable", "es2022"],
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "@effect/language-service",
+				"ignoreEffectWarningsInTscExitCode": true
+			},
+			{ "name": "next" }
+		],
+		"types": ["bun-types", "node"],
+		"paths": {
+			"@/*": ["./*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,21 @@
         "effect": "^3.21.0",
       },
     },
+    "apps/mock-channel": {
+      "name": "@amby/mock-channel",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "16",
+        "react": "19",
+        "react-dom": "19",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "bun-types": "latest",
+      },
+    },
     "apps/web": {
       "name": "@amby/web",
       "version": "0.1.0",
@@ -274,6 +289,8 @@
     "@amby/env": ["@amby/env@workspace:packages/env"],
 
     "@amby/memory": ["@amby/memory@workspace:packages/memory"],
+
+    "@amby/mock-channel": ["@amby/mock-channel@workspace:apps/mock-channel"],
 
     "@amby/web": ["@amby/web@workspace:apps/web"],
 
@@ -1916,6 +1933,8 @@
     "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
     "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
+
+    "@amby/mock-channel/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 


### PR DESCRIPTION
## Summary
- Adds a catch-all Next.js API route at `apps/mock-channel/app/api/mock-bot/[...path]/route.ts` that acts as a mock Telegram Bot API server
- Supports `sendMessage`, `editMessageText`, `deleteMessage`, `sendChatAction`, `setMyCommands`, and `getMe` methods
- Includes shared lib modules: `telegram-types.ts` (type definitions), `message-store.ts` (in-memory message persistence with HMR-safe globalThis singleton), `sse-emitter.ts` (pub/sub event emitter)
- All unknown methods return `{ ok: true }` to avoid breaking the backend

## Test plan
- [x] Unit tests pass (`bun test` -- 8 tests, 20 assertions)
- [ ] Integration: point backend `TELEGRAM_API_BASE_URL` at `http://localhost:3100/api/mock-bot` and verify bot responses appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)