### PR TITLE
Add chat UI components for mock Telegram channel

### DIFF
--- a/apps/mock-channel/app/globals.css
+++ b/apps/mock-channel/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/apps/mock-channel/app/layout.tsx
+++ b/apps/mock-channel/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next"
+import "./globals.css"
+
+export const metadata: Metadata = {
+	title: "Mock Telegram Channel",
+	description: "Dev-only mock Telegram channel for testing",
+}
+
+export default function RootLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return (
+		<html lang="en" className="dark">
+			<body className="bg-neutral-950 text-neutral-100 antialiased">
+				{children}
+			</body>
+		</html>
+	)
+}

--- a/apps/mock-channel/components/chat-container.tsx
+++ b/apps/mock-channel/components/chat-container.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useState, useEffect, useCallback, useRef } from "react"
+import type { StoredMessage, MockUserConfig } from "../lib/telegram-types"
+import { MessageList } from "./message-list"
+import { MessageInput } from "./message-input"
+
+export function ChatContainer({ user }: { user: MockUserConfig }) {
+	const [messages, setMessages] = useState<StoredMessage[]>([])
+	const [isTyping, setIsTyping] = useState(false)
+	const [isSending, setIsSending] = useState(false)
+	const typingTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+	// Subscribe to SSE events
+	useEffect(() => {
+		const eventSource = new EventSource("/api/events")
+
+		eventSource.addEventListener("message", (e) => {
+			const msg: StoredMessage = JSON.parse(e.data)
+			setMessages((prev) => {
+				// Avoid duplicates
+				if (prev.some((m) => m.message_id === msg.message_id)) return prev
+				return [...prev, msg]
+			})
+			setIsTyping(false)
+		})
+
+		eventSource.addEventListener("edit", (e) => {
+			const edited: StoredMessage = JSON.parse(e.data)
+			setMessages((prev) =>
+				prev.map((m) => (m.message_id === edited.message_id ? edited : m)),
+			)
+		})
+
+		eventSource.addEventListener("delete", (e) => {
+			const { message_id } = JSON.parse(e.data) as { message_id: number }
+			setMessages((prev) => prev.filter((m) => m.message_id !== message_id))
+		})
+
+		eventSource.addEventListener("typing", () => {
+			setIsTyping(true)
+			if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current)
+			typingTimeoutRef.current = setTimeout(() => setIsTyping(false), 6000)
+		})
+
+		eventSource.addEventListener("clear", () => {
+			setMessages([])
+			setIsTyping(false)
+		})
+
+		return () => {
+			eventSource.close()
+			if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current)
+		}
+	}, [])
+
+	const handleSend = useCallback(
+		async (text: string) => {
+			setIsSending(true)
+
+			// Optimistically add user message
+			const optimisticMsg: StoredMessage = {
+				message_id: -(Date.now()),
+				chat_id: user.chatId,
+				text,
+				from_bot: false,
+				date: Math.floor(Date.now() / 1000),
+			}
+			setMessages((prev) => [...prev, optimisticMsg])
+
+			try {
+				const response = await fetch("/api/send", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ text, user }),
+				})
+
+				if (!response.ok) {
+					const error = await response.json()
+					console.error("Send failed:", error)
+				}
+			} catch (error) {
+				console.error("Send error:", error)
+			} finally {
+				setIsSending(false)
+			}
+		},
+		[user],
+	)
+
+	return (
+		<div className="flex h-full flex-col">
+			<MessageList messages={messages} isTyping={isTyping} />
+			<MessageInput onSend={handleSend} disabled={isSending} />
+		</div>
+	)
+}

--- a/apps/mock-channel/components/message-bubble.tsx
+++ b/apps/mock-channel/components/message-bubble.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import type { StoredMessage } from "../lib/telegram-types"
+
+export function MessageBubble({ message }: { message: StoredMessage }) {
+	const isUser = !message.from_bot
+	return (
+		<div className={`flex ${isUser ? "justify-end" : "justify-start"} mb-2`}>
+			<div
+				className={`max-w-[75%] rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap ${
+					isUser
+						? "bg-blue-600 text-white rounded-br-sm"
+						: "bg-neutral-800 text-neutral-100 rounded-bl-sm"
+				} ${message.edited ? "border border-neutral-600" : ""}`}
+			>
+				{message.text}
+				{message.edited && (
+					<span className="ml-2 text-[10px] opacity-50">(edited)</span>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/apps/mock-channel/components/message-input.tsx
+++ b/apps/mock-channel/components/message-input.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState, useCallback, type KeyboardEvent } from "react"
+import { Send } from "lucide-react"
+
+export function MessageInput({
+	onSend,
+	disabled,
+}: {
+	onSend: (text: string) => void
+	disabled?: boolean
+}) {
+	const [text, setText] = useState("")
+
+	const handleSend = useCallback(() => {
+		const trimmed = text.trim()
+		if (!trimmed || disabled) return
+		onSend(trimmed)
+		setText("")
+	}, [text, disabled, onSend])
+
+	const handleKeyDown = useCallback(
+		(e: KeyboardEvent<HTMLTextAreaElement>) => {
+			if (e.key === "Enter" && !e.shiftKey) {
+				e.preventDefault()
+				handleSend()
+			}
+		},
+		[handleSend],
+	)
+
+	return (
+		<div className="border-t border-neutral-800 p-4">
+			<div className="flex items-end gap-2">
+				<textarea
+					value={text}
+					onChange={(e) => setText(e.target.value)}
+					onKeyDown={handleKeyDown}
+					placeholder="Type a message..."
+					disabled={disabled}
+					rows={1}
+					className="flex-1 resize-none rounded-xl bg-neutral-800 px-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+				/>
+				<button
+					onClick={handleSend}
+					disabled={disabled || !text.trim()}
+					className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:opacity-30 disabled:hover:bg-blue-600"
+				>
+					<Send size={18} />
+				</button>
+			</div>
+		</div>
+	)
+}

--- a/apps/mock-channel/components/message-list.tsx
+++ b/apps/mock-channel/components/message-list.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import type { StoredMessage } from "../lib/telegram-types"
+import { MessageBubble } from "./message-bubble"
+
+export function MessageList({
+	messages,
+	isTyping,
+}: {
+	messages: StoredMessage[]
+	isTyping: boolean
+}) {
+	const bottomRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+	}, [messages.length, isTyping])
+
+	return (
+		<div className="flex-1 overflow-y-auto px-4 py-4">
+			{messages.length === 0 && (
+				<div className="flex h-full items-center justify-center text-neutral-500 text-sm">
+					Send a message to start the conversation
+				</div>
+			)}
+			{messages.map((msg) => (
+				<MessageBubble key={`${msg.message_id}-${msg.text.slice(0, 20)}`} message={msg} />
+			))}
+			{isTyping && (
+				<div className="flex justify-start mb-2">
+					<div className="bg-neutral-800 rounded-2xl rounded-bl-sm px-4 py-2 text-sm text-neutral-400">
+						<span className="animate-pulse">typing...</span>
+					</div>
+				</div>
+			)}
+			<div ref={bottomRef} />
+		</div>
+	)
+}

--- a/apps/mock-channel/lib/config.ts
+++ b/apps/mock-channel/lib/config.ts
@@ -1,0 +1,13 @@
+import type { MockUserConfig } from "./telegram-types"
+
+/** Default mock user for local development. */
+export const DEFAULT_USER: MockUserConfig = {
+	chatId: 100001,
+	userId: 1,
+	firstName: "Test",
+	lastName: "User",
+	username: "testuser",
+}
+
+/** Port the mock channel dev server runs on. */
+export const MOCK_CHANNEL_PORT = 3100

--- a/apps/mock-channel/lib/telegram-types.ts
+++ b/apps/mock-channel/lib/telegram-types.ts
@@ -1,0 +1,18 @@
+/** A message stored in the mock channel's in-memory store. */
+export interface StoredMessage {
+	message_id: number
+	chat_id: number
+	text: string
+	from_bot: boolean
+	date: number
+	edited?: boolean
+}
+
+/** Configuration for the mock user sending messages. */
+export interface MockUserConfig {
+	chatId: number
+	userId: number
+	firstName: string
+	lastName?: string
+	username?: string
+}

--- a/apps/mock-channel/next-env.d.ts
+++ b/apps/mock-channel/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/mock-channel/next.config.ts
+++ b/apps/mock-channel/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next"
+
+const nextConfig: NextConfig = {}
+
+export default nextConfig

--- a/apps/mock-channel/package.json
+++ b/apps/mock-channel/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@amby/mock-channel",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev --port 3100",
+		"build": "next build",
+		"start": "next start --port 3100",
+		"typecheck": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome check .",
+		"lint:fix": "bunx @biomejs/biome check --fix .",
+		"format": "bunx @biomejs/biome format --write ."
+	},
+	"dependencies": {
+		"clsx": "^2.1.1",
+		"lucide-react": "^0.577.0",
+		"next": "16",
+		"react": "19",
+		"react-dom": "19",
+		"tailwind-merge": "^3.5.0"
+	},
+	"devDependencies": {
+		"@tailwindcss/postcss": "^4.2.1",
+		"@types/node": "^25.5.0",
+		"@types/react": "^19.2.14",
+		"@types/react-dom": "^19.2.3",
+		"bun-types": "^1.2.21",
+		"postcss": "^8.5.6",
+		"tailwindcss": "^4.2.1"
+	}
+}

--- a/apps/mock-channel/postcss.config.mjs
+++ b/apps/mock-channel/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+}
+
+export default config

--- a/apps/mock-channel/tsconfig.json
+++ b/apps/mock-channel/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["dom", "dom.iterable", "es2022"],
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [{ "name": "next" }],
+		"types": ["node"],
+		"paths": {
+			"@/*": ["./*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,27 @@
         "effect": "^3.21.0",
       },
     },
+    "apps/mock-channel": {
+      "name": "@amby/mock-channel",
+      "version": "0.1.0",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.577.0",
+        "next": "16",
+        "react": "19",
+        "react-dom": "19",
+        "tailwind-merge": "^3.5.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.1",
+        "@types/node": "^25.5.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "bun-types": "^1.2.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.2.1",
+      },
+    },
     "apps/web": {
       "name": "@amby/web",
       "version": "0.1.0",
@@ -274,6 +295,8 @@
     "@amby/env": ["@amby/env@workspace:packages/env"],
 
     "@amby/memory": ["@amby/memory@workspace:packages/memory"],
+
+    "@amby/mock-channel": ["@amby/mock-channel@workspace:apps/mock-channel"],
 
     "@amby/web": ["@amby/web@workspace:apps/web"],
 


### PR DESCRIPTION
## Summary
- Scaffold `apps/mock-channel` Next.js 16 app with Tailwind CSS 4, PostCSS, and TypeScript config
- Create four client components: `MessageBubble`, `MessageList`, `MessageInput`, `ChatContainer`
- `ChatContainer` subscribes to SSE events (`/api/events`) and sends messages via `POST /api/send` with optimistic updates
- Add shared `lib/telegram-types.ts` (StoredMessage, MockUserConfig) and `lib/config.ts` (default user, port)

## Test plan
- [x] `bun run build` passes successfully
- [ ] Manual: verify message bubbles render with correct alignment (user right, bot left)
- [ ] Manual: verify SSE event handling (message, edit, delete, typing, clear)
- [ ] Manual: verify Enter sends message, Shift+Enter adds newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)