### PR TITLE
Add mock Telegram channel app with debug panel and user config

### DIFF
--- a/apps/mock-channel/app/api/clear/route.ts
+++ b/apps/mock-channel/app/api/clear/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server"
+import { clearMessages, clearRequestLog } from "../../../lib/message-store"
+
+export async function POST() {
+	clearMessages()
+	clearRequestLog()
+	return NextResponse.json({ ok: true })
+}

--- a/apps/mock-channel/app/api/send/route.ts
+++ b/apps/mock-channel/app/api/send/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server"
+import type { MockUserConfig } from "../../../lib/telegram-types"
+import {
+	addMessage,
+	getMessages,
+	addRequestLogEntry,
+} from "../../../lib/message-store"
+import { buildWebhookUpdate } from "../../../lib/webhook-builder"
+import { emitSSE } from "../../../lib/sse-emitter"
+
+export async function POST(request: Request) {
+	const body = await request.json()
+	const { text, user } = body as { text: string; user: MockUserConfig }
+
+	if (!text || !user) {
+		return NextResponse.json(
+			{ error: "Missing text or user" },
+			{ status: 400 },
+		)
+	}
+
+	const userMsg = addMessage("user", text)
+	emitSSE("message", userMsg)
+
+	const update = buildWebhookUpdate(text, user, Number(userMsg.id))
+	const webhookUrl = `${user.backendUrl}/api/telegram/webhook`
+
+	addRequestLogEntry({
+		direction: "outbound",
+		method: "POST",
+		url: webhookUrl,
+		body: update,
+	})
+
+	try {
+		const res = await fetch(webhookUrl, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Telegram-Bot-Api-Secret-Token": user.webhookSecret,
+			},
+			body: JSON.stringify(update),
+		})
+
+		const responseBody = await res.text()
+
+		addRequestLogEntry({
+			direction: "inbound",
+			method: "POST",
+			url: webhookUrl,
+			body: update,
+			response: { status: res.status, body: responseBody },
+		})
+
+		// Telegram webhook responses can include a sendMessage action
+		try {
+			const parsed = JSON.parse(responseBody)
+			if (parsed.method === "sendMessage" && parsed.text) {
+				const botMsg = addMessage("bot", parsed.text)
+				emitSSE("message", botMsg)
+			}
+		} catch {
+			/* response may not be JSON */
+		}
+	} catch (err) {
+		addRequestLogEntry({
+			direction: "inbound",
+			method: "POST",
+			url: webhookUrl,
+			body: { error: String(err) },
+		})
+	}
+
+	return NextResponse.json({ messages: getMessages() })
+}

--- a/apps/mock-channel/app/api/sse/route.ts
+++ b/apps/mock-channel/app/api/sse/route.ts
@@ -1,0 +1,36 @@
+import { addSSEListener } from "../../../lib/sse-emitter"
+
+export async function GET(request: Request) {
+	const stream = new ReadableStream({
+		start(controller) {
+			const encoder = new TextEncoder()
+
+			const remove = addSSEListener((data: string) => {
+				controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+			})
+
+			const heartbeat = setInterval(() => {
+				try {
+					controller.enqueue(encoder.encode(": heartbeat\n\n"))
+				} catch {
+					clearInterval(heartbeat)
+					remove()
+				}
+			}, 30_000)
+
+			// Clean up when client disconnects
+			request.signal.addEventListener("abort", () => {
+				clearInterval(heartbeat)
+				remove()
+			})
+		},
+	})
+
+	return new Response(stream, {
+		headers: {
+			"Content-Type": "text/event-stream",
+			"Cache-Control": "no-cache",
+			Connection: "keep-alive",
+		},
+	})
+}

--- a/apps/mock-channel/app/api/state/route.ts
+++ b/apps/mock-channel/app/api/state/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server"
+import { getMessages, getRequestLog } from "../../../lib/message-store"
+
+export async function GET() {
+	return NextResponse.json({
+		messages: getMessages(),
+		requestLog: getRequestLog(),
+	})
+}

--- a/apps/mock-channel/app/globals.css
+++ b/apps/mock-channel/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/apps/mock-channel/app/layout.tsx
+++ b/apps/mock-channel/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next"
+import "./globals.css"
+
+export const metadata: Metadata = {
+	title: "Mock Telegram Channel",
+	description: "Dev-only mock Telegram channel for local testing",
+}
+
+export default function RootLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return (
+		<html lang="en" className="dark">
+			<body className="bg-neutral-950 text-neutral-100 antialiased">
+				{children}
+			</body>
+		</html>
+	)
+}

--- a/apps/mock-channel/app/page.tsx
+++ b/apps/mock-channel/app/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { ChatContainer } from "../components/chat-container"
+import { DebugPanel } from "../components/debug-panel"
+import { UserConfigPanel, useUserConfig } from "../components/user-config"
+import { useState } from "react"
+import { PanelRightOpen, PanelRightClose } from "lucide-react"
+
+export default function Home() {
+	const { config, updateConfig, resetConfig, loaded } = useUserConfig()
+	const [showDebug, setShowDebug] = useState(true)
+
+	const handleClear = async () => {
+		await fetch("/api/clear", { method: "POST" })
+	}
+
+	if (!loaded) {
+		return (
+			<main className="flex h-screen items-center justify-center">
+				<div className="text-neutral-500 text-sm">Loading...</div>
+			</main>
+		)
+	}
+
+	return (
+		<main className="flex h-screen">
+			{/* Chat area */}
+			<div
+				className={`flex flex-col ${showDebug ? "w-[65%]" : "w-full"}`}
+			>
+				<UserConfigPanel
+					config={config}
+					onUpdate={updateConfig}
+					onReset={resetConfig}
+					onClear={handleClear}
+				/>
+				<ChatContainer user={config} />
+			</div>
+
+			{/* Debug toggle */}
+			<button
+				onClick={() => setShowDebug(!showDebug)}
+				className="absolute right-2 top-2 z-10 rounded p-1.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-300"
+				title={showDebug ? "Hide debug panel" : "Show debug panel"}
+			>
+				{showDebug ? (
+					<PanelRightClose size={16} />
+				) : (
+					<PanelRightOpen size={16} />
+				)}
+			</button>
+
+			{/* Debug panel */}
+			{showDebug && (
+				<div className="w-[35%]">
+					<DebugPanel />
+				</div>
+			)}
+		</main>
+	)
+}

--- a/apps/mock-channel/components/chat-container.tsx
+++ b/apps/mock-channel/components/chat-container.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import type { MockUserConfig, DisplayMessage } from "../lib/telegram-types"
+import { MessageList } from "./message-list"
+import { MessageInput } from "./message-input"
+
+export function ChatContainer({ user }: { user: MockUserConfig }) {
+	const [messages, setMessages] = useState<DisplayMessage[]>([])
+	const [sending, setSending] = useState(false)
+
+	// Poll for messages and also listen to SSE
+	useEffect(() => {
+		const fetchMessages = async () => {
+			try {
+				const res = await fetch("/api/state")
+				const data = await res.json()
+				setMessages(data.messages ?? [])
+			} catch {
+				/* ignore */
+			}
+		}
+
+		fetchMessages()
+
+		// SSE for real-time updates
+		const eventSource = new EventSource("/api/sse")
+		eventSource.onmessage = (event) => {
+			try {
+				const parsed = JSON.parse(event.data)
+				if (parsed.event === "message") {
+					fetchMessages()
+				}
+			} catch {
+				/* ignore */
+			}
+		}
+
+		// Fallback polling
+		const interval = setInterval(fetchMessages, 3000)
+
+		return () => {
+			eventSource.close()
+			clearInterval(interval)
+		}
+	}, [])
+
+	const handleSend = useCallback(
+		async (text: string) => {
+			setSending(true)
+			try {
+				const res = await fetch("/api/send", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ text, user }),
+				})
+				if (res.ok) {
+					const data = await res.json()
+					setMessages(data.messages ?? [])
+				}
+			} catch {
+				/* ignore */
+			} finally {
+				setSending(false)
+			}
+		},
+		[user],
+	)
+
+	return (
+		<div className="flex flex-1 flex-col overflow-hidden">
+			<MessageList messages={messages} />
+			<MessageInput onSend={handleSend} disabled={sending} />
+		</div>
+	)
+}

--- a/apps/mock-channel/components/debug-panel.tsx
+++ b/apps/mock-channel/components/debug-panel.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import type { RequestLogEntry } from "../lib/telegram-types"
+import { Bug, ChevronRight, ChevronDown } from "lucide-react"
+
+export function DebugPanel() {
+	const [entries, setEntries] = useState<RequestLogEntry[]>([])
+	const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+	// Poll for request log updates
+	useEffect(() => {
+		const poll = async () => {
+			try {
+				const res = await fetch("/api/state")
+				const data = await res.json()
+				setEntries(data.requestLog ?? [])
+			} catch {
+				/* ignore */
+			}
+		}
+
+		poll()
+		const interval = setInterval(poll, 2000)
+		return () => clearInterval(interval)
+	}, [])
+
+	const toggleExpand = (id: string) => {
+		setExpanded((prev) => {
+			const next = new Set(prev)
+			if (next.has(id)) next.delete(id)
+			else next.add(id)
+			return next
+		})
+	}
+
+	return (
+		<div className="flex h-full flex-col border-l border-neutral-800">
+			<div className="flex items-center gap-2 border-b border-neutral-800 px-3 py-2">
+				<Bug size={14} className="text-neutral-400" />
+				<span className="text-xs font-medium text-neutral-300">
+					Debug Log
+				</span>
+				<span className="text-[10px] text-neutral-600">
+					{entries.length} entries
+				</span>
+			</div>
+			<div className="flex-1 overflow-y-auto text-xs">
+				{entries.length === 0 && (
+					<div className="p-3 text-neutral-600">No requests yet</div>
+				)}
+				{[...entries].reverse().map((entry) => (
+					<div key={entry.id} className="border-b border-neutral-800/50">
+						<button
+							onClick={() => toggleExpand(entry.id)}
+							className="flex w-full items-start gap-1 px-3 py-2 text-left hover:bg-neutral-800/30"
+						>
+							{expanded.has(entry.id) ? (
+								<ChevronDown
+									size={12}
+									className="mt-0.5 shrink-0 text-neutral-500"
+								/>
+							) : (
+								<ChevronRight
+									size={12}
+									className="mt-0.5 shrink-0 text-neutral-500"
+								/>
+							)}
+							<div className="min-w-0 flex-1">
+								<div className="flex items-center gap-2">
+									<span
+										className={`font-mono text-[10px] ${
+											entry.direction === "inbound"
+												? "text-green-400"
+												: "text-blue-400"
+										}`}
+									>
+										{entry.direction === "inbound"
+											? "-> WEBHOOK"
+											: "<- BOT API"}
+									</span>
+									<span className="text-neutral-500">
+										{new Date(entry.timestamp).toLocaleTimeString()}
+									</span>
+								</div>
+								<div className="mt-0.5 truncate text-neutral-400 font-mono">
+									{entry.method}{" "}
+									{entry.url.split("/").slice(-2).join("/")}
+								</div>
+							</div>
+						</button>
+						{expanded.has(entry.id) && (
+							<div className="bg-neutral-900 px-3 py-2">
+								<div className="mb-1 text-[10px] text-neutral-500">
+									Request Body
+								</div>
+								<pre className="overflow-x-auto whitespace-pre-wrap break-all text-[10px] text-neutral-300 font-mono">
+									{JSON.stringify(entry.body, null, 2)}
+								</pre>
+								{entry.response && (
+									<>
+										<div className="mt-2 mb-1 text-[10px] text-neutral-500">
+											Response ({entry.response.status})
+										</div>
+										<pre className="overflow-x-auto whitespace-pre-wrap break-all text-[10px] text-neutral-300 font-mono">
+											{typeof entry.response.body === "string"
+												? entry.response.body.slice(0, 500)
+												: JSON.stringify(
+														entry.response.body,
+														null,
+														2,
+													)}
+										</pre>
+									</>
+								)}
+							</div>
+						)}
+					</div>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/apps/mock-channel/components/message-bubble.tsx
+++ b/apps/mock-channel/components/message-bubble.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import type { DisplayMessage } from "../lib/telegram-types"
+
+export function MessageBubble({ message }: { message: DisplayMessage }) {
+	const isUser = message.role === "user"
+
+	return (
+		<div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+			<div
+				className={`max-w-[75%] rounded-2xl px-4 py-2 text-sm ${
+					isUser
+						? "bg-blue-600 text-white"
+						: "bg-neutral-800 text-neutral-200"
+				}`}
+			>
+				<p className="whitespace-pre-wrap break-words">{message.text}</p>
+				<div
+					className={`mt-1 text-[10px] ${
+						isUser ? "text-blue-200" : "text-neutral-500"
+					}`}
+				>
+					{new Date(message.timestamp).toLocaleTimeString()}
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/apps/mock-channel/components/message-input.tsx
+++ b/apps/mock-channel/components/message-input.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { Send } from "lucide-react"
+
+export function MessageInput({
+	onSend,
+	disabled,
+}: {
+	onSend: (text: string) => void
+	disabled?: boolean
+}) {
+	const [text, setText] = useState("")
+
+	const handleSubmit = useCallback(() => {
+		const trimmed = text.trim()
+		if (!trimmed || disabled) return
+		onSend(trimmed)
+		setText("")
+	}, [text, disabled, onSend])
+
+	return (
+		<div className="border-t border-neutral-800 px-4 py-3">
+			<div className="flex items-end gap-2">
+				<textarea
+					value={text}
+					onChange={(e) => setText(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" && !e.shiftKey) {
+							e.preventDefault()
+							handleSubmit()
+						}
+					}}
+					placeholder="Type a message..."
+					rows={1}
+					disabled={disabled}
+					className="flex-1 resize-none rounded-lg bg-neutral-800 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-600 disabled:opacity-50"
+				/>
+				<button
+					onClick={handleSubmit}
+					disabled={disabled || !text.trim()}
+					className="rounded-lg bg-blue-600 p-2 text-white hover:bg-blue-500 disabled:opacity-50 disabled:hover:bg-blue-600"
+				>
+					<Send size={16} />
+				</button>
+			</div>
+		</div>
+	)
+}

--- a/apps/mock-channel/components/message-list.tsx
+++ b/apps/mock-channel/components/message-list.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import type { DisplayMessage } from "../lib/telegram-types"
+import { MessageBubble } from "./message-bubble"
+
+export function MessageList({ messages }: { messages: DisplayMessage[] }) {
+	const bottomRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+	}, [messages])
+
+	return (
+		<div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+			{messages.length === 0 && (
+				<div className="flex h-full items-center justify-center text-sm text-neutral-600">
+					Send a message to start the conversation
+				</div>
+			)}
+			{messages.map((msg) => (
+				<MessageBubble key={msg.id} message={msg} />
+			))}
+			<div ref={bottomRef} />
+		</div>
+	)
+}

--- a/apps/mock-channel/components/user-config.tsx
+++ b/apps/mock-channel/components/user-config.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import type { MockUserConfig } from "../lib/telegram-types"
+import { Settings, RotateCcw } from "lucide-react"
+
+const STORAGE_KEY = "mock-channel-user-config"
+
+const DEFAULT_CONFIG: MockUserConfig = {
+	telegramUserId: 99001,
+	firstName: "Dev",
+	lastName: "Tester",
+	username: "devtester",
+	chatId: 99001,
+	backendUrl: "http://localhost:3001",
+	webhookSecret: "dev-secret",
+}
+
+export function useUserConfig() {
+	const [config, setConfig] = useState<MockUserConfig>(DEFAULT_CONFIG)
+	const [loaded, setLoaded] = useState(false)
+
+	useEffect(() => {
+		const stored = localStorage.getItem(STORAGE_KEY)
+		if (stored) {
+			try {
+				setConfig({ ...DEFAULT_CONFIG, ...JSON.parse(stored) })
+			} catch {
+				/* use defaults */
+			}
+		}
+		setLoaded(true)
+	}, [])
+
+	const updateConfig = useCallback((updates: Partial<MockUserConfig>) => {
+		setConfig((prev) => {
+			const next = { ...prev, ...updates }
+			localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+			return next
+		})
+	}, [])
+
+	const resetConfig = useCallback(() => {
+		localStorage.removeItem(STORAGE_KEY)
+		setConfig(DEFAULT_CONFIG)
+	}, [])
+
+	return { config, updateConfig, resetConfig, loaded }
+}
+
+export function UserConfigPanel({
+	config,
+	onUpdate,
+	onReset,
+	onClear,
+}: {
+	config: MockUserConfig
+	onUpdate: (updates: Partial<MockUserConfig>) => void
+	onReset: () => void
+	onClear: () => void
+}) {
+	const [expanded, setExpanded] = useState(false)
+
+	return (
+		<div className="border-b border-neutral-800">
+			<div className="flex items-center justify-between px-4 py-2">
+				<div className="flex items-center gap-2 text-sm">
+					<span className="font-medium">{config.firstName}</span>
+					<span className="text-neutral-500">@{config.username}</span>
+					<span className="text-neutral-600">chat:{config.chatId}</span>
+				</div>
+				<div className="flex items-center gap-1">
+					<button
+						onClick={onClear}
+						className="rounded p-1.5 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
+						title="Clear conversation"
+					>
+						<RotateCcw size={14} />
+					</button>
+					<button
+						onClick={() => setExpanded(!expanded)}
+						className="rounded p-1.5 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
+						title="Settings"
+					>
+						<Settings size={14} />
+					</button>
+				</div>
+			</div>
+			{expanded && (
+				<div className="border-t border-neutral-800 px-4 py-3 space-y-2">
+					<div className="grid grid-cols-2 gap-2">
+						<label className="text-xs text-neutral-400">
+							User ID
+							<input
+								type="number"
+								value={config.telegramUserId}
+								onChange={(e) =>
+									onUpdate({ telegramUserId: Number(e.target.value) })
+								}
+								className="mt-1 block w-full rounded bg-neutral-800 px-2 py-1 text-xs text-neutral-200"
+							/>
+						</label>
+						<label className="text-xs text-neutral-400">
+							Chat ID
+							<input
+								type="number"
+								value={config.chatId}
+								onChange={(e) =>
+									onUpdate({ chatId: Number(e.target.value) })
+								}
+								className="mt-1 block w-full rounded bg-neutral-800 px-2 py-1 text-xs text-neutral-200"
+							/>
+						</label>
+						<label className="text-xs text-neutral-400">
+							First Name
+							<input
+								type="text"
+								value={config.firstName}
+								onChange={(e) => onUpdate({ firstName: e.target.value })}
+								className="mt-1 block w-full rounded bg-neutral-800 px-2 py-1 text-xs text-neutral-200"
+							/>
+						</label>
+						<label className="text-xs text-neutral-400">
+							Username
+							<input
+								type="text"
+								value={config.username ?? ""}
+								onChange={(e) => onUpdate({ username: e.target.value })}
+								className="mt-1 block w-full rounded bg-neutral-800 px-2 py-1 text-xs text-neutral-200"
+							/>
+						</label>
+					</div>
+					<label className="text-xs text-neutral-400 block">
+						Backend URL
+						<input
+							type="text"
+							value={config.backendUrl}
+							onChange={(e) => onUpdate({ backendUrl: e.target.value })}
+							className="mt-1 block w-full rounded bg-neutral-800 px-2 py-1 text-xs text-neutral-200"
+						/>
+					</label>
+					<label className="text-xs text-neutral-400 block">
+						Webhook Secret
+						<input
+							type="text"
+							value={config.webhookSecret}
+							onChange={(e) => onUpdate({ webhookSecret: e.target.value })}
+							className="mt-1 block w-full rounded bg-neutral-800 px-2 py-1 text-xs text-neutral-200 font-mono"
+						/>
+					</label>
+					<button
+						onClick={onReset}
+						className="text-xs text-red-400 hover:text-red-300"
+					>
+						Reset to defaults
+					</button>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/apps/mock-channel/lib/config.ts
+++ b/apps/mock-channel/lib/config.ts
@@ -1,0 +1,5 @@
+/** App-level configuration constants */
+
+export const BOT_USER_ID = 1_000_000
+export const BOT_USERNAME = "amby_bot"
+export const BOT_FIRST_NAME = "Amby"

--- a/apps/mock-channel/lib/message-store.ts
+++ b/apps/mock-channel/lib/message-store.ts
@@ -1,0 +1,49 @@
+import type { DisplayMessage, RequestLogEntry } from "./telegram-types"
+
+/** Server-side only — survives across API calls but not server restarts. */
+
+let messages: DisplayMessage[] = []
+let requestLog: RequestLogEntry[] = []
+let nextMessageId = 1
+
+export function getMessages(): DisplayMessage[] {
+	return messages
+}
+
+export function addMessage(role: "user" | "bot", text: string): DisplayMessage {
+	const msg: DisplayMessage = {
+		id: String(nextMessageId++),
+		role,
+		text,
+		timestamp: Date.now(),
+	}
+	messages.push(msg)
+	return msg
+}
+
+export function clearMessages(): void {
+	messages = []
+	nextMessageId = 1
+}
+
+export function getRequestLog(): RequestLogEntry[] {
+	return requestLog
+}
+
+export function addRequestLogEntry(entry: Omit<RequestLogEntry, "id" | "timestamp">): RequestLogEntry {
+	const full: RequestLogEntry = {
+		...entry,
+		id: crypto.randomUUID(),
+		timestamp: Date.now(),
+	}
+	requestLog.push(full)
+	// Keep only last 100 entries
+	if (requestLog.length > 100) {
+		requestLog = requestLog.slice(-100)
+	}
+	return full
+}
+
+export function clearRequestLog(): void {
+	requestLog = []
+}

--- a/apps/mock-channel/lib/sse-emitter.ts
+++ b/apps/mock-channel/lib/sse-emitter.ts
@@ -1,0 +1,20 @@
+/**
+ * Simple SSE (Server-Sent Events) emitter for pushing updates to the UI.
+ * Server-side only.
+ */
+
+type Listener = (data: string) => void
+
+const listeners = new Set<Listener>()
+
+export function addSSEListener(listener: Listener): () => void {
+	listeners.add(listener)
+	return () => listeners.delete(listener)
+}
+
+export function emitSSE(event: string, data: unknown): void {
+	const payload = JSON.stringify({ event, data })
+	for (const listener of listeners) {
+		listener(payload)
+	}
+}

--- a/apps/mock-channel/lib/telegram-types.ts
+++ b/apps/mock-channel/lib/telegram-types.ts
@@ -1,0 +1,63 @@
+/** Minimal Telegram-compatible types for the mock channel */
+
+export interface TelegramUser {
+	id: number
+	is_bot: boolean
+	first_name: string
+	last_name?: string
+	username?: string
+}
+
+export interface TelegramChat {
+	id: number
+	type: "private" | "group" | "supergroup" | "channel"
+	first_name?: string
+	last_name?: string
+	username?: string
+}
+
+export interface TelegramMessage {
+	message_id: number
+	from: TelegramUser
+	chat: TelegramChat
+	date: number
+	text?: string
+}
+
+export interface TelegramUpdate {
+	update_id: number
+	message?: TelegramMessage
+}
+
+/** User-configurable identity for the mock channel */
+export interface MockUserConfig {
+	telegramUserId: number
+	firstName: string
+	lastName?: string
+	username?: string
+	chatId: number
+	backendUrl: string
+	webhookSecret: string
+}
+
+/** A display message in the mock channel UI */
+export interface DisplayMessage {
+	id: string
+	role: "user" | "bot"
+	text: string
+	timestamp: number
+}
+
+/** Request log entry for the debug panel */
+export interface RequestLogEntry {
+	id: string
+	timestamp: number
+	direction: "inbound" | "outbound"
+	method: string
+	url: string
+	body: unknown
+	response?: {
+		status: number
+		body: unknown
+	}
+}

--- a/apps/mock-channel/lib/webhook-builder.ts
+++ b/apps/mock-channel/lib/webhook-builder.ts
@@ -1,0 +1,35 @@
+import type { MockUserConfig, TelegramUpdate } from "./telegram-types"
+
+let updateIdCounter = 1
+
+/**
+ * Build a Telegram-compatible webhook update payload from a user message.
+ */
+export function buildWebhookUpdate(
+	text: string,
+	config: MockUserConfig,
+	messageId: number,
+): TelegramUpdate {
+	return {
+		update_id: updateIdCounter++,
+		message: {
+			message_id: messageId,
+			from: {
+				id: config.telegramUserId,
+				is_bot: false,
+				first_name: config.firstName,
+				last_name: config.lastName,
+				username: config.username,
+			},
+			chat: {
+				id: config.chatId,
+				type: "private",
+				first_name: config.firstName,
+				last_name: config.lastName,
+				username: config.username,
+			},
+			date: Math.floor(Date.now() / 1000),
+			text,
+		},
+	}
+}

--- a/apps/mock-channel/next-env.d.ts
+++ b/apps/mock-channel/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/mock-channel/next.config.ts
+++ b/apps/mock-channel/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next"
+
+const nextConfig: NextConfig = {
+	reactStrictMode: true,
+}
+
+export default nextConfig

--- a/apps/mock-channel/package.json
+++ b/apps/mock-channel/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@amby/mock-channel",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev --port 3002",
+		"build": "next build",
+		"start": "next start --port 3002",
+		"typecheck": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome check .",
+		"lint:fix": "bunx @biomejs/biome check --fix ."
+	},
+	"dependencies": {
+		"lucide-react": "^0.577.0",
+		"next": "16",
+		"react": "19",
+		"react-dom": "19"
+	},
+	"devDependencies": {
+		"@tailwindcss/postcss": "^4.2.1",
+		"@types/node": "^25.5.0",
+		"@types/react": "^19.2.14",
+		"@types/react-dom": "^19.2.3",
+		"postcss": "^8.5.8",
+		"tailwindcss": "^4.2.1",
+		"typescript": "^5.8.0"
+	}
+}

--- a/apps/mock-channel/postcss.config.mjs
+++ b/apps/mock-channel/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+}
+
+export default config

--- a/apps/mock-channel/tsconfig.json
+++ b/apps/mock-channel/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["dom", "dom.iterable", "es2022"],
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [{ "name": "next" }],
+		"types": ["node"],
+		"paths": {
+			"@/*": ["./*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,25 @@
         "effect": "^3.21.0",
       },
     },
+    "apps/mock-channel": {
+      "name": "@amby/mock-channel",
+      "version": "0.1.0",
+      "dependencies": {
+        "lucide-react": "^0.577.0",
+        "next": "16",
+        "react": "19",
+        "react-dom": "19",
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.1",
+        "@types/node": "^25.5.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "postcss": "^8.5.8",
+        "tailwindcss": "^4.2.1",
+        "typescript": "^5.8.0",
+      },
+    },
     "apps/web": {
       "name": "@amby/web",
       "version": "0.1.0",
@@ -274,6 +293,8 @@
     "@amby/env": ["@amby/env@workspace:packages/env"],
 
     "@amby/memory": ["@amby/memory@workspace:packages/memory"],
+
+    "@amby/mock-channel": ["@amby/mock-channel@workspace:apps/mock-channel"],
 
     "@amby/web": ["@amby/web@workspace:apps/web"],
 


### PR DESCRIPTION
## Summary
- Creates `apps/mock-channel` — a dev-only Next.js app for locally testing Telegram bot interactions without a real Telegram connection
- Adds user identity editor (persisted in localStorage) with configurable user ID, chat ID, name, backend URL, and webhook secret
- Adds collapsible debug sidebar showing timestamped webhook request/response logs with expandable JSON details
- Includes full chat UI (message list, input, SSE real-time updates) and API routes (send, state, clear, SSE)
- Typed Telegram message/update builders for webhook simulation

## Test plan
- [x] `bun run build` passes in `apps/mock-channel`
- [ ] Manual: run `bun run dev` in `apps/mock-channel`, verify chat UI renders
- [ ] Manual: expand settings panel, change user config, verify persistence across reload
- [ ] Manual: toggle debug panel visibility
- [ ] Manual: send a message and verify it appears in both chat and debug log

🤖 Generated with [Claude Code](https://claude.com/claude-code)