### PR TITLE
Fix typecheck errors in apps/mock package

### DIFF
--- a/apps/mock/app/api/mock-bot/[...path]/route.ts
+++ b/apps/mock/app/api/mock-bot/[...path]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server"
+import { type NextRequest, NextResponse } from "next/server"
 import { addMessage, addRequestLogEntry } from "../../../../lib/message-store"
 import { emitSSE } from "../../../../lib/sse-emitter"
 
@@ -23,7 +23,7 @@ export async function POST(
 	} else if (contentType.includes("multipart/form-data")) {
 		const formData = await request.formData()
 		for (const [key, value] of formData.entries()) {
-			body[key] = typeof value === "string" ? value : value.name
+			body[key] = typeof value === "string" ? value : (value as unknown as File).name
 		}
 	}
 

--- a/apps/mock/lib/telegram-types.ts
+++ b/apps/mock/lib/telegram-types.ts
@@ -6,6 +6,7 @@ export interface TelegramUser {
 	first_name: string
 	last_name?: string
 	username?: string
+	language_code?: string
 }
 
 export interface TelegramChat {

--- a/apps/mock/package.json
+++ b/apps/mock/package.json
@@ -25,6 +25,7 @@
 		"@types/react-dom": "^19.2.3",
 		"postcss": "^8.5.8",
 		"tailwindcss": "^4.2.1",
+		"bun-types": "^1.3.10",
 		"typescript": "^5.8.0"
 	}
 }

--- a/apps/mock/tsconfig.json
+++ b/apps/mock/tsconfig.json
@@ -5,7 +5,7 @@
 		"jsx": "preserve",
 		"incremental": true,
 		"plugins": [{ "name": "next" }],
-		"types": ["node"],
+		"types": ["node", "bun-types"],
 		"paths": {
 			"@/*": ["./*"]
 		}

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "bun-types": "^1.3.10",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.1",
         "typescript": "^5.8.0",


### PR DESCRIPTION
## Summary
- Add `bun-types` to `tsconfig.json` types array and `package.json` devDependencies to resolve `bun:test` module resolution errors in test files
- Add `language_code?: string` to `TelegramUser` interface to match the Telegram Bot API spec, fixing TS2339/TS2353 errors in webhook-builder
- Fix `FormDataEntryValue` type narrowing in mock-bot route handler where bun-types overrides the standard `File` type

## Test plan
- [x] `bun run typecheck` in `apps/mock` passes with zero errors
- [x] `bun test` in `apps/mock` passes (12 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)