### PR TITLE
Use idiomatic yield* for yieldable errors in memory and connectors

### DIFF
--- a/packages/connectors/src/service.ts
+++ b/packages/connectors/src/service.ts
@@ -560,11 +560,9 @@ export const ConnectorsServiceLive = Layer.effect(
 					})
 					const redirectUrl = request.redirectUrl
 					if (!redirectUrl) {
-						return yield* Effect.fail(
-							new ConnectorsError({
-								message: "missing_authorization_redirect_url",
-							}),
-						)
+						return yield* new ConnectorsError({
+							message: "missing_authorization_redirect_url",
+						})
 					}
 
 					const rowId = yield* upsertPendingAuthRequest(
@@ -669,11 +667,9 @@ export const ConnectorsServiceLive = Layer.effect(
 					)
 
 					if (!matchingAccount) {
-						return yield* Effect.fail(
-							new ConnectorsError({
-								message: "connected_account_not_found",
-							}),
-						)
+						return yield* new ConnectorsError({
+							message: "connected_account_not_found",
+						})
 					}
 
 					yield* Effect.tryPromise({
@@ -776,19 +772,15 @@ export const ConnectorsServiceLive = Layer.effect(
 					const composio = yield* ensureClient()
 
 					if (!env.COMPOSIO_WEBHOOK_SECRET) {
-						return yield* Effect.fail(
-							new ConnectorsError({
-								message: "missing_webhook_secret",
-							}),
-						)
+						return yield* new ConnectorsError({
+							message: "missing_webhook_secret",
+						})
 					}
 
 					if (!headers.signature || !headers.webhookId || !headers.webhookTimestamp) {
-						return yield* Effect.fail(
-							new ConnectorsError({
-								message: "missing_webhook_headers",
-							}),
-						)
+						return yield* new ConnectorsError({
+							message: "missing_webhook_headers",
+						})
 					}
 					const signature = headers.signature
 					const webhookId = headers.webhookId

--- a/packages/memory/src/repository.ts
+++ b/packages/memory/src/repository.ts
@@ -35,8 +35,7 @@ export const MemoryServiceLive = Layer.effect(
 							.returning({ id: schema.memories.id }),
 					)
 					const row = rows[0]
-					if (!row)
-						return yield* Effect.fail(new MemoryError({ message: "Insert returned no rows" }))
+					if (!row) return yield* new MemoryError({ message: "Insert returned no rows" })
 					return row.id
 				}).pipe(
 					Effect.mapError((e) => new MemoryError({ message: "Failed to add memory", cause: e })),


### PR DESCRIPTION
## Summary
- Replace `yield* Effect.fail(new ConnectorsError(...))` with `yield* new ConnectorsError(...)` at 4 locations in `packages/connectors/src/service.ts`
- Replace `yield* Effect.fail(new MemoryError(...))` with `yield* new MemoryError(...)` in `packages/memory/src/repository.ts`
- Both error types extend yieldable error classes, so `Effect.fail` wrapping is unnecessary

## Test plan
- [x] `bun run typecheck` passes with zero errors/suggestions for both packages
- [x] `bun test` passes (30/30) in connectors package
- [x] `bun run format` and `bun run lint:fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)