### PR TITLE
Fix typecheck suggestions in packages/agent

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -6,7 +6,7 @@ import { DbService, schema } from "@amby/db"
 import { EnvService } from "@amby/env"
 import { createMemoryTools, MemoryService } from "@amby/memory"
 import { stepCountIs, ToolLoopAgent, type ToolSet, tool } from "ai"
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Runtime } from "effect"
 import { z } from "zod"
 import { prepareConversationContext } from "./context/builder"
 import { AgentError } from "./errors"
@@ -399,6 +399,7 @@ export const makeAgentServiceLive = (userId: string) =>
 						requestMetadata: metadata ?? null,
 					})
 					rootTraceRef = rootTrace
+					const rt = yield* Effect.runtime<never>()
 					yield* rootTrace.append("context_built", {
 						threadId: threadCtx.threadId,
 						sharedPromptContext: prepared.sharedPromptContext,
@@ -414,7 +415,7 @@ export const makeAgentServiceLive = (userId: string) =>
 								...(createConnectorManagementTools(connectors, userId) ?? {}),
 								...((yield* connectors
 									.getAgentTools(userId)
-									.pipe(Effect.catchAll(() => Effect.succeed(undefined)))) ?? {}),
+									.pipe(Effect.catchAll(() => Effect.void))) ?? {}),
 							} as ToolSet)
 						: undefined
 					const cuaTools = config.runtime.cuaEnabled
@@ -472,7 +473,7 @@ export const makeAgentServiceLive = (userId: string) =>
 									rootTrace,
 								})
 								state.execution = summary
-								await Effect.runPromise(rootTrace.setMode(summary.mode))
+								await Runtime.runPromise(rt)(rootTrace.setMode(summary.mode))
 								return {
 									mode: summary.mode,
 									status: summary.status,
@@ -510,7 +511,7 @@ export const makeAgentServiceLive = (userId: string) =>
 								}),
 							]),
 							async execute(input) {
-								const result = await Effect.runPromise(
+								const result = await Runtime.runPromise(rt)(
 									queryExecution({
 										query,
 										supervisor: taskSupervisor,
@@ -548,7 +549,7 @@ export const makeAgentServiceLive = (userId: string) =>
 							agentRole: "conversation",
 						}),
 						experimental_onStepStart: async (event) => {
-							await Effect.runPromise(
+							await Runtime.runPromise(rt)(
 								rootTrace.append("model_request", {
 									stepNumber: event.stepNumber,
 									activeTools: event.activeTools,
@@ -556,7 +557,7 @@ export const makeAgentServiceLive = (userId: string) =>
 							)
 						},
 						onStepFinish: async (event) => {
-							await Effect.runPromise(
+							await Runtime.runPromise(rt)(
 								rootTrace.append("model_response", {
 									finishReason: event.finishReason,
 									text: event.text,
@@ -684,13 +685,11 @@ export const makeAgentServiceLive = (userId: string) =>
 									.complete("failed", { error: toErrorMessage(error) })
 									.pipe(Effect.catchAll(() => Effect.void))
 							}
-							if (error instanceof AgentError) return yield* Effect.fail(error)
-							return yield* Effect.fail(
-								new AgentError({
-									message: "Agent request failed",
-									cause: error,
-								}),
-							)
+							if (error instanceof AgentError) return yield* error
+							return yield* new AgentError({
+								message: "Agent request failed",
+								cause: error,
+							})
 						}),
 					),
 				)

--- a/packages/agent/src/execution/runners/browser.test.ts
+++ b/packages/agent/src/execution/runners/browser.test.ts
@@ -39,12 +39,12 @@ function makeBrowserService(result: BrowserTaskResult) {
 
 const trace = {
 	traceId: "trace-1",
-	append: () => Effect.succeed<void>(undefined),
-	appendMany: () => Effect.succeed<void>(undefined),
-	setMode: () => Effect.succeed<void>(undefined),
-	updateMetadata: () => Effect.succeed<void>(undefined),
-	linkMessage: () => Effect.succeed<void>(undefined),
-	complete: () => Effect.succeed<void>(undefined),
+	append: () => Effect.void,
+	appendMany: () => Effect.void,
+	setMode: () => Effect.void,
+	updateMetadata: () => Effect.void,
+	linkMessage: () => Effect.void,
+	complete: () => Effect.void,
 }
 
 describe("runBrowserSpecialist", () => {

--- a/packages/agent/src/router.ts
+++ b/packages/agent/src/router.ts
@@ -311,7 +311,7 @@ export function ensureDefaultThread(
 
 		if (fallback[0]) return fallback[0].id
 
-		return yield* Effect.fail(new AgentError({ message: "Failed to create default thread" }))
+		return yield* new AgentError({ message: "Failed to create default thread" })
 	}).pipe(
 		Effect.mapError(
 			(e) =>
@@ -405,7 +405,7 @@ export function resolveThread(
 				)
 				const row = rows[0]
 				if (!row) {
-					return yield* Effect.fail(new AgentError({ message: "Failed to create native thread" }))
+					return yield* new AgentError({ message: "Failed to create native thread" })
 				}
 				threadId = row.id
 			}
@@ -523,7 +523,7 @@ export function resolveThread(
 			)
 			const row = rows[0]
 			if (!row) {
-				return yield* Effect.fail(new AgentError({ message: "Failed to insert new thread" }))
+				return yield* new AgentError({ message: "Failed to insert new thread" })
 			}
 			resolvedThreadId = row.id
 		}

--- a/packages/agent/src/synopsis.ts
+++ b/packages/agent/src/synopsis.ts
@@ -125,5 +125,5 @@ export function synopsisCurrentThreadIfOverflowsAfterSave(
 			conversationId,
 			threadCtx.threadId === threadCtx.defaultThreadId,
 		)
-	}).pipe(Effect.catchAll(() => Effect.void))
+	})
 }


### PR DESCRIPTION
## Summary
- Replace `yield* Effect.fail(new AgentError(...))` with `yield* new AgentError(...)` in router.ts and agent.ts (5 locations) — AgentError extends Data.TaggedError which is directly yieldable
- Replace `Effect.runPromise(...)` with `Runtime.runPromise(rt)(...)` in agent.ts async callbacks (4 locations) — captures runtime at the Effect boundary for proper use in non-Effect async contexts
- Replace `Effect.succeed<void>(undefined)` with `Effect.void` in browser.test.ts mock trace (6 locations)
- Remove unnecessary `catchAll` on unfailable effect in synopsis.ts
- Replace `Effect.succeed(undefined)` with `Effect.void` in connector tools error handler

## Test plan
- [x] `bun run typecheck` in packages/agent — all assigned file suggestions resolved
- [x] `bun test` in packages/agent — 40 tests pass
- [x] `bun run format` — no changes needed
- [x] `bun run lint:fix` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)