### PR TITLE
Add README.md for db, env, and auth packages

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,37 @@
+# @amby/auth
+
+User authentication and API key management for the Amby platform.
+
+## Responsibilities
+
+- Configure Better Auth with Drizzle adapter and PostgreSQL
+- Provide `AuthService` (Effect service tag) for auth operations
+- Support email + password authentication
+- Support API key authentication via `@better-auth/api-key` plugin
+
+## Non-responsibilities
+
+- No integration OAuth flows (handled by `@amby/connectors`)
+- No user profile management or business logic
+- No direct route/handler definitions
+
+## Key modules
+
+| Path | Description |
+|------|-------------|
+| `src/index.ts` | `AuthService` tag, `AuthServiceLive` layer, Better Auth configuration |
+
+## Public surface
+
+```ts
+import { AuthService, AuthServiceLive } from "@amby/auth"
+```
+
+## Dependency rules
+
+- **Depends on:** `@amby/db`, `@amby/env`
+- **Depended on by:** app layers (API server, Workers)
+
+## Links
+
+- [Architecture](../../docs/ARCHITECTURE.md)

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,52 @@
+# @amby/db
+
+Database schema, migrations, and query service for the Amby platform.
+
+## Responsibilities
+
+- Define all PostgreSQL table schemas via Drizzle ORM
+- Provide `DbService` (Effect service tag) for typed database access
+- Own migrations and schema evolution
+- Export re-usable Drizzle query operators (`eq`, `and`, `sql`, etc.)
+- Supply runtime-specific layers: `DbServiceLive` (Bun/Node), `makeDbServiceFromHyperdrive` (Workers)
+
+## Non-responsibilities
+
+- No business logic or domain rules
+- No direct API or HTTP handling
+- No environment loading (delegates to `@amby/env`)
+
+## Key modules
+
+| Path | Description |
+|------|-------------|
+| `src/schema/` | Table definitions: users, conversations, tasks, task-events, jobs, memories, sandboxes, connectors |
+| `src/service.ts` | `DbService` tag, `DbServiceLive` layer, `makeDbServiceFromHyperdrive` factory |
+| `src/errors.ts` | `DbError` and `NotFoundError` tagged error types |
+| `drizzle/` | Generated migrations (10) and relation definitions |
+
+## Public surface
+
+```ts
+import { DbService, DbServiceLive, makeDbServiceFromHyperdrive } from "@amby/db"
+import * as schema from "@amby/db/schema"
+```
+
+## Dependency rules
+
+- **Depends on:** `@amby/env`
+- **Depended on by:** `@amby/auth`, `@amby/agent`, and app layers
+
+## Commands
+
+| Script | Purpose |
+|--------|---------|
+| `db:generate` | Generate a new migration from schema changes |
+| `db:migrate` | Apply pending migrations |
+| `db:push` | Push schema directly (dev only) |
+| `db:studio` | Open Drizzle Studio GUI |
+
+## Links
+
+- [Architecture](../../docs/ARCHITECTURE.md)
+- [Database design](../../docs/DATABASE.md)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -1,0 +1,42 @@
+# @amby/env
+
+Environment configuration and runtime-specific platform abstractions.
+
+## Responsibilities
+
+- Define the canonical `Env` interface listing all configuration variables
+- Provide `EnvService` (Effect service tag) for typed config access
+- Supply `EnvServiceLive` for Bun/Node runtimes (reads from `process.env` via Effect Config)
+- Supply `makeEnvServiceFromBindings` for Cloudflare Workers runtimes
+- Define `WorkflowBinding` and `WorkflowInstanceHandle` interfaces for portable workflow primitives
+
+## Non-responsibilities
+
+- No secrets management or rotation logic
+- No runtime business logic
+- No direct database or API access
+
+## Key modules
+
+| Path | Description |
+|------|-------------|
+| `src/shared.ts` | `Env` interface, `EnvService` tag, `EnvError`, workflow binding types |
+| `src/local.ts` | `EnvServiceLive` layer for Bun/Node; `makeEffectDevToolsLive` helper |
+| `src/workers.ts` | `WorkerBindings` interface, `makeEnvServiceFromBindings` factory |
+
+## Public surface
+
+```ts
+import { EnvService, type Env } from "@amby/env"
+import { EnvServiceLive } from "@amby/env/local"
+import { makeEnvServiceFromBindings } from "@amby/env/workers"
+```
+
+## Dependency rules
+
+- **Depends on:** `@effect/experimental`, `@effect/platform` (peer: `effect`)
+- **Depended on by:** `@amby/db`, `@amby/auth`, `@amby/agent`, and all app layers
+
+## Links
+
+- [Architecture](../../docs/ARCHITECTURE.md)


### PR DESCRIPTION
## Summary
- Add `packages/db/README.md` — documents schema, migrations, DbService, and Drizzle commands
- Add `packages/env/README.md` — documents Env interface, EnvService, and runtime-specific layers
- Add `packages/auth/README.md` — documents AuthService, Better Auth config, and API key support
- Skipped `packages/core` — package does not exist in this repo

Each README follows a consistent pattern: purpose, responsibilities, non-responsibilities, key modules, public surface, dependency rules, and links.

## Test plan
- [x] Markdown renders correctly (no broken tables or code blocks)
- [x] All referenced file paths and exports match actual source code
- [x] All dependency claims verified against package.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)