### PR TITLE
Add capability package READMEs

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,0 +1,44 @@
+# @amby/agent
+
+Agent orchestration, model inference, tool routing, and execution coordination.
+
+## Responsibilities
+
+- Resolve conversation threads (4-stage routing: default, stale, native, derived)
+- Assemble context from history, memory, summaries, and plugins
+- Run conversation turns via Vercel AI SDK ToolLoopAgent (max 8 steps)
+- Plan and coordinate execution (direct, sequential, parallel, background modes)
+- Provide direct tools: save/search memories, send messages, execute plans, query execution
+
+## Non-responsibilities
+
+- No direct Telegram or channel handling (that is `@amby/channels`)
+- No HTTP endpoints or webhook processing (that is the Cloudflare worker)
+- No memory storage or embedding (that is `@amby/memory` and `@amby/db`)
+
+## Key modules
+
+| File | Purpose |
+|---|---|
+| `src/agent.ts` | AgentService composition — wires tools, plugins, and services |
+| `src/router.ts` | Thread resolution (4-stage routing) |
+| `src/context/builder.ts` | Context assembly (history, memory, summaries) |
+| `src/execution/coordinator.ts` | Plan execution orchestrator |
+| `src/execution/planner.ts` | Execution plan generation |
+| `src/execution/registry.ts` | Tool group registry |
+| `src/tools/messaging.ts` | Reply and job tools |
+| `src/models.ts` | LLM provider setup |
+| `src/telemetry.ts` | Trace and span management |
+
+## Public surface
+
+Exported from `src/index.ts`: `AgentService`, `AgentError`, job utilities, model config, router, synopsis, messaging tools, and type definitions for agent, browser, execution, persistence, and settings.
+
+## Dependency rules
+
+- **Depends on:** core (`@amby/db`, `@amby/env`), `@amby/memory`, `@amby/browser`, `@amby/computer`, `@amby/connectors`, `@amby/channels`
+- **Depended on by:** Cloudflare worker runtime (`apps/`)
+
+## Links
+
+- [Architecture](../../docs/ARCHITECTURE.md)

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,0 +1,40 @@
+# @amby/browser
+
+Web automation and data extraction via Stagehand (Playwright-based).
+
+## Responsibilities
+
+- Define the `BrowserService` interface and typed task model (input, result, progress)
+- Provide local implementation using Bun + Playwright (`./local`)
+- Provide Cloudflare Browser Rendering implementation (`./workers`)
+- Support three task modes: extract, act, agent
+- Classify side-effect levels (read, soft-write, hard-write) and detect escalation signals
+
+## Non-responsibilities
+
+- No tool registration (tool definitions live in `@amby/agent` browser-tools)
+- No task persistence or execution tracking
+- No agent orchestration
+
+## Key modules
+
+| File | Purpose |
+|---|---|
+| `src/shared.ts` | BrowserService tag, types, mode/side-effect inference, URL sanitization |
+| `src/local.ts` | Local Playwright-based Stagehand implementation |
+| `src/workers.ts` | Cloudflare Browser Rendering implementation |
+
+## Public surface
+
+- Default export (`"."`): types, `BrowserService` tag, helper functions from `shared.ts`
+- `"./local"`: local browser provider
+- `"./workers"`: Cloudflare workers browser provider
+
+## Dependency rules
+
+- **Depends on:** `@amby/env`
+- **Depended on by:** `@amby/agent`
+
+## Links
+
+- [Architecture](../../docs/ARCHITECTURE.md)

--- a/packages/computer/README.md
+++ b/packages/computer/README.md
@@ -1,0 +1,44 @@
+# @amby/computer
+
+Sandbox task execution and volume management via Daytona.
+
+## Responsibilities
+
+- Provision and manage sandboxes (disposable runtimes on durable per-user volumes)
+- Supervise task execution with heartbeat, state tracking, and result collection
+- Provide sandbox tools (`execute_in_sandbox`, CUA tools) as AI SDK tool definitions
+- Resolve sandbox and volume state for users
+- Export sandbox configuration for external consumers
+
+## Non-responsibilities
+
+- No tool registration with the agent (tool wiring is in `@amby/agent`)
+- No task persistence to database (that is `@amby/db` via the agent layer)
+- No agent orchestration or planning
+
+## Key modules
+
+| File | Purpose |
+|---|---|
+| `src/sandbox/service.ts` | Sandbox provisioning and lifecycle management |
+| `src/sandbox/tools.ts` | AI SDK tool definitions for sandbox execution |
+| `src/sandbox/resolve-sandbox.ts` | Sandbox state resolution |
+| `src/sandbox/resolve-volume.ts` | Volume state resolution |
+| `src/harness/supervisor.ts` | Task supervision, heartbeat, result collection |
+| `src/harness/task-state.ts` | Task state machine |
+| `src/harness/provider.ts` | Harness provider |
+| `src/config.ts` | Sandbox configuration |
+| `src/sandbox-config.ts` | Exported sandbox config |
+
+## Public surface
+
+Exported from `src/index.ts`: `SandboxService`, `TaskSupervisor`, `createComputerTools`, `createCuaTools`, harness utilities, config, and error types. Separate `"./sandbox-config"` export for external config consumers.
+
+## Dependency rules
+
+- **Depends on:** `@amby/db`, `@amby/env`, `@amby/connectors`
+- **Depended on by:** `@amby/agent`
+
+## Links
+
+- [Architecture](../../docs/ARCHITECTURE.md)

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -1,0 +1,39 @@
+# @amby/memory
+
+User memory management with semantic search via pgvector.
+
+## Responsibilities
+
+- CRUD operations for user memories with pgvector semantic search
+- Categorize memories: static (user-set), dynamic (agent-learned), inference (agent-inferred)
+- Provide AI SDK tools: `save_memory`, `search_memories`, `forget_memory`
+- LRU in-memory caching for hot memory lookups
+- Generate memory context prompts for agent turns
+
+## Non-responsibilities
+
+- No embedding generation (embeddings are produced externally)
+- No agent orchestration or tool routing (that is `@amby/agent`)
+
+## Key modules
+
+| File | Purpose |
+|---|---|
+| `src/repository.ts` | MemoryService — CRUD + pgvector semantic search |
+| `src/tools.ts` | AI SDK tool definitions (save, search, forget) |
+| `src/cache.ts` | LRU in-memory cache |
+| `src/prompt-builder.ts` | Memory prompt generation for agent context |
+| `src/types.ts` | Memory type definitions |
+
+## Public surface
+
+Exported from `src/index.ts`: `MemoryService`, `createMemoryTools`, `MemoryCache`, `MemoryPromptBuilder`, error types, and memory type definitions.
+
+## Dependency rules
+
+- **Depends on:** `@amby/db`
+- **Depended on by:** `@amby/agent`
+
+## Links
+
+- [Architecture](../../docs/ARCHITECTURE.md)


### PR DESCRIPTION
## Summary
- Add README.md for `@amby/agent`, `@amby/memory`, `@amby/browser`, and `@amby/computer` packages
- Each README follows a consistent pattern: purpose, responsibilities, non-responsibilities, key modules, public surface, dependency rules, and links
- All kept under 50 lines per the documentation guidelines
- Note: `packages/plugins` and `packages/skills` do not exist in this repo, so no READMEs were created for them

## Test plan
- [x] Verify markdown renders correctly
- [x] Verify accuracy against source code (package.json, index.ts, key modules)
- [x] Confirm all four READMEs follow the same structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)