### PR TITLE
Move plugin-registry to packages/plugins

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,12 +12,12 @@ import {
 	ConnectorsService,
 	ConnectorsServiceLive,
 } from "@amby/plugins/integrations"
+import { PluginRegistryLive } from "@amby/plugins/registry"
 import type { Chat } from "chat"
 import { Effect, Either, Layer, ManagedRuntime } from "effect"
 import { Hono } from "hono"
 import { createAmbyBot } from "./bot"
 import { getHomeResponse } from "./home"
-import { PluginRegistryLive } from "./shared/plugin-registry"
 import { TelegramSenderLite } from "./telegram"
 
 // Shared layers — constructed once at startup

--- a/apps/api/src/queue/runtime.ts
+++ b/apps/api/src/queue/runtime.ts
@@ -7,8 +7,8 @@ import { makeEnvServiceFromBindings, type WorkerBindings } from "@amby/env/worke
 import { MemoryServiceLive } from "@amby/memory"
 import { AutomationServiceLive } from "@amby/plugins"
 import { ConnectorsServiceLive } from "@amby/plugins/integrations"
+import { PluginRegistryLive } from "@amby/plugins/registry"
 import { Layer, ManagedRuntime } from "effect"
-import { PluginRegistryLive } from "../shared/plugin-registry"
 import { TelegramSenderLite } from "../telegram"
 
 const makeBaseLive = (bindings: WorkerBindings) => {

--- a/apps/api/src/scripts/test-telegram-flow.ts
+++ b/apps/api/src/scripts/test-telegram-flow.ts
@@ -17,8 +17,8 @@ import { EnvServiceLive, makeEffectDevToolsLive } from "@amby/env/local"
 import { MemoryServiceLive } from "@amby/memory"
 import { AutomationServiceLive } from "@amby/plugins"
 import { ConnectorsServiceLive } from "@amby/plugins/integrations"
+import { PluginRegistryLive } from "@amby/plugins/registry"
 import { Effect, Layer, ManagedRuntime } from "effect"
-import { PluginRegistryLive } from "../shared/plugin-registry"
 
 // --- Test Configuration ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -212,6 +212,8 @@
         "@amby/core": "workspace:*",
         "@amby/db": "workspace:*",
         "@amby/env": "workspace:*",
+        "@amby/memory": "workspace:*",
+        "@amby/skills": "workspace:*",
         "@composio/core": "0.6.5",
         "@composio/vercel": "0.6.5",
         "croner": "^9.0.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",
-		"./integrations": "./src/integrations/index.ts"
+		"./integrations": "./src/integrations/index.ts",
+		"./registry": "./src/registry/index.ts"
 	},
 	"scripts": {
 		"typecheck": "tsc --noEmit",
@@ -15,6 +16,8 @@
 		"@amby/core": "workspace:*",
 		"@amby/db": "workspace:*",
 		"@amby/env": "workspace:*",
+		"@amby/memory": "workspace:*",
+		"@amby/skills": "workspace:*",
 		"@composio/core": "0.6.5",
 		"@composio/vercel": "0.6.5",
 		"croner": "^9.0.0"

--- a/packages/plugins/src/registry/composition.ts
+++ b/packages/plugins/src/registry/composition.ts
@@ -1,17 +1,17 @@
 import { CoreError, createPluginRegistry, PluginRegistryService, registerPlugins } from "@amby/core"
 import { DbService } from "@amby/db"
 import { createMemoryPlugin, MemoryService } from "@amby/memory"
+import { createSkillService, createSkillsPlugin } from "@amby/skills"
+import { Effect, Layer } from "effect"
 import {
 	AutomationService,
 	adaptAutomationService,
 	computeNextCronRun,
 	createAutomationsPlugin,
-	createBrowserToolsPlugin,
-	createComputerToolsPlugin,
-} from "@amby/plugins"
-import { ConnectorsService, createIntegrationsPlugin } from "@amby/plugins/integrations"
-import { createSkillService, createSkillsPlugin } from "@amby/skills"
-import { Effect, Layer } from "effect"
+} from "../automations"
+import { createBrowserToolsPlugin } from "../browser-tools"
+import { createComputerToolsPlugin } from "../computer-tools"
+import { ConnectorsService, createIntegrationsPlugin } from "../integrations"
 
 /**
  * Build the PluginRegistry Layer from resolved services.

--- a/packages/plugins/src/registry/index.ts
+++ b/packages/plugins/src/registry/index.ts
@@ -1,0 +1,1 @@
+export { PluginRegistryLive } from "./composition"


### PR DESCRIPTION
## Summary
- Move plugin-registry composition root from `apps/api/src/shared/` to `packages/plugins/src/registry/` so any app entry point can import it via `@amby/plugins/registry`
- Add `@amby/memory` and `@amby/skills` as explicit dependencies of `@amby/plugins` (required by the registry)
- Rewire all 3 import sites in `apps/api` and delete the now-empty `shared/` directory

## Test plan
- [x] `bun install` resolves cleanly with new workspace dependencies
- [x] `bun run typecheck` passes all 13 packages (plugins and api re-checked as cache misses)
- [x] `bun run lint` passes with zero errors (import ordering fixed)
- [x] `bun run test` -- pre-existing failures only, no regressions from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes the plugin-registry composition root from an `apps/api`-private module (`src/shared/plugin-registry.ts`) into the shared `@amby/plugins` package (`packages/plugins/src/registry/`), making it importable by any workspace app via `@amby/plugins/registry`. The three import sites in `apps/api` are correctly rewired, the `shared/` directory is fully removed, and `@amby/memory` / `@amby/skills` are added as explicit dependencies of `@amby/plugins` to satisfy the registry's compile-time requirements.

Key changes:
- `packages/plugins/src/registry/composition.ts` — the moved file now uses package-internal relative imports (`../automations`, `../browser-tools`, etc.) rather than its old public package imports (`@amby/plugins`, `@amby/plugins/integrations`), which is cleaner and avoids any round-trip through the public API surface.
- `packages/plugins/package.json` — adds the `./registry` conditional export and the two new workspace dependencies.
- `bun.lock` — updated consistently with the manifest change.
- All three `apps/api` call sites — straightforward import-path swap, no logic changes.

<h3>Confidence Score: 5/5</h3>

Pure refactoring with no logic changes — safe to merge.

All three import sites are correctly updated, the shared directory is fully removed, the package manifest and lock file are consistent, and the new relative imports inside the package are correct. No behaviour changes were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/plugins/src/registry/composition.ts | Moved from apps/api/src/shared/plugin-registry.ts; replaced public package imports with package-internal relative imports for automations, browser-tools, computer-tools, and integrations — no logic changes. |
| packages/plugins/src/registry/index.ts | New barrel export file, re-exports PluginRegistryLive from composition.ts to expose the registry endpoint. |
| packages/plugins/package.json | Added ./registry export path and @amby/memory, @amby/skills as explicit workspace dependencies to support the composition root. |
| apps/api/src/index.ts | Rewired PluginRegistryLive import from ./shared/plugin-registry to @amby/plugins/registry — import ordering also fixed. |
| apps/api/src/queue/runtime.ts | Rewired PluginRegistryLive import from ../shared/plugin-registry to @amby/plugins/registry. |
| apps/api/src/scripts/test-telegram-flow.ts | Rewired PluginRegistryLive import from ../shared/plugin-registry to @amby/plugins/registry — no other changes. |
| bun.lock | Lock file correctly reflects the addition of @amby/memory and @amby/skills as workspace dependencies of @amby/plugins. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph apps_api["apps/api"]
        idx["src/index.ts"]
        rt["src/queue/runtime.ts"]
        scr["src/scripts/test-telegram-flow.ts"]
    end

    subgraph plugins["@amby/plugins"]
        reg_idx["registry/index.ts"]
        comp["registry/composition.ts"]
        auto["automations/"]
        browser["browser-tools/"]
        computer["computer-tools/"]
        integ["integrations/"]
    end

    subgraph deps["Workspace Deps (new)"]
        mem["@amby/memory"]
        skills["@amby/skills"]
    end

    idx -->|"@amby/plugins/registry"| reg_idx
    rt -->|"@amby/plugins/registry"| reg_idx
    scr -->|"@amby/plugins/registry"| reg_idx
    reg_idx --> comp
    comp --> auto
    comp --> browser
    comp --> computer
    comp --> integ
    comp --> mem
    comp --> skills
```

<sub>Reviews (1): Last reviewed commit: ["Move plugin-registry composition root fr..."](https://github.com/punitarani/amby/commit/bed49bd6e03bd681fa6dcfb8e713fe8bb868b35f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26531802)</sub>

<!-- /greptile_comment -->