### PR TITLE
Narrow Platform type + remove workspaceKey

### DIFF
--- a/apps/api/src/telegram/utils.ts
+++ b/apps/api/src/telegram/utils.ts
@@ -218,7 +218,6 @@ const ensureTelegramConversation = (userId: string, chatId: number) =>
 					userId,
 					platform: "telegram",
 					externalConversationKey: String(chatId),
-					workspaceKey: "",
 				})
 				.onConflictDoNothing(),
 		)

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -7,10 +7,10 @@ Channels are transport adapters that connect external messaging surfaces to the 
 The platform type is defined in `packages/db/src/schema/conversations.ts`:
 
 ```typescript
-type Platform = "cli" | "telegram" | "slack" | "discord"
+type Platform = "telegram"
 ```
 
-Only **Telegram** is implemented today. `slack` and `discord` are reserved for future use. `cli` exists for local development.
+Only **Telegram** is implemented today. New platform values will be added when additional channels are built.
 
 ## Telegram inbound flow
 
@@ -59,9 +59,9 @@ sequenceDiagram
 | Telegram user | `from.id` (numeric) | `123456789` |
 | DB account | `accounts.providerId="telegram"`, `accounts.accountId=from.id` | provider lookup |
 | DB user | `users.id` (UUID) | created on first message |
-| Conversation | `userId + platform + workspaceKey + externalConversationKey` | unique index |
+| Conversation | `userId + platform + externalConversationKey` | unique index |
 
-For Telegram, `externalConversationKey` = `String(chatId)` and `workspaceKey` = `""`.
+For Telegram, `externalConversationKey` = `String(chatId)`.
 
 The `findOrCreateUser` function in `apps/api/src/telegram/utils.ts` handles upsert logic: find existing account by `(providerId=telegram, accountId=from.id)`, or create a new user + account in a transaction.
 
@@ -118,7 +118,7 @@ The mock constructs realistic `TelegramUpdate` JSON payloads (`lib/webhook-build
 
 To add a new channel (e.g., Slack):
 
-1. Add the platform value to the `Platform` type in `packages/db/src/schema/conversations.ts` (already present for slack/discord)
+1. Add the platform value to the `Platform` type in `packages/db/src/schema/conversations.ts` and `packages/core/src/domain/platform.ts`
 2. Create an adapter package or use an existing chat-adapter library
 3. Implement an inbound webhook handler that parses platform updates and calls `findOrCreateUser` + `AgentService.ensureConversation` + `AgentService.handleMessage`
 4. Implement outbound delivery (send/edit/stream via platform API)

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -66,11 +66,11 @@ erDiagram
 
 | Table | Purpose | Key constraints |
 |---|---|---|
-| `conversations` | Platform-scoped container. One per user + platform + workspace + external key. | unique on `(userId, platform, workspaceKey, externalConversationKey)` |
+| `conversations` | Platform-scoped container. One per user + platform + external key. | unique on `(userId, platform, externalConversationKey)` |
 | `conversation_threads` | Internal routing layer (topic threads). Source: `native`, `reply_chain`, `derived`, `manual`. | Exactly one `isDefault=true` per conversation (partial unique index). Unique `externalThreadKey` per conversation when non-null. |
 | `messages` | User-visible transcript only. Role: `user` or `assistant`. | **Not** the execution log. Indexed by `(conversationId, createdAt)`. |
 
-Platform types: `cli`, `telegram`, `slack`, `discord`.
+Platform types: `telegram`.
 
 ### Execution traces
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -45,7 +45,6 @@ export class AgentService extends Context.Tag("AgentService")<
 		readonly ensureConversation: (
 			platform: Platform,
 			externalConversationKey: string,
-			workspaceKey?: string,
 		) => Effect.Effect<string, AgentError>
 		readonly shutdown: () => Effect.Effect<void, AgentError>
 	}
@@ -203,7 +202,7 @@ export const makeAgentServiceLive = (userId: string) =>
 						onPart,
 					}),
 
-				ensureConversation: (platform, externalConversationKey, workspaceKey) =>
+				ensureConversation: (platform, externalConversationKey) =>
 					query((database) =>
 						database
 							.insert(schema.conversations)
@@ -211,13 +210,11 @@ export const makeAgentServiceLive = (userId: string) =>
 								userId,
 								platform,
 								externalConversationKey,
-								workspaceKey: workspaceKey ?? "",
 							})
 							.onConflictDoUpdate({
 								target: [
 									schema.conversations.userId,
 									schema.conversations.platform,
-									schema.conversations.workspaceKey,
 									schema.conversations.externalConversationKey,
 								],
 								set: { updatedAt: new Date() },

--- a/packages/db/src/schema/conversations.ts
+++ b/packages/db/src/schema/conversations.ts
@@ -14,7 +14,7 @@ import { users } from "./users"
 
 // --- Types ---
 
-export type Platform = "cli" | "telegram" | "slack" | "discord"
+export type Platform = "telegram"
 export type ThreadSource = "native" | "reply_chain" | "derived" | "manual"
 export type SpecialistKind =
 	| "conversation"
@@ -49,7 +49,6 @@ export const conversations = pgTable(
 			.notNull()
 			.references(() => users.id, { onDelete: "cascade" }),
 		platform: text("platform").$type<Platform>().notNull(),
-		workspaceKey: text("workspace_key").notNull().default(""),
 		externalConversationKey: text("external_conversation_key").notNull(),
 		title: text("title"),
 		metadata: jsonb("metadata").$type<Record<string, unknown>>(),
@@ -60,7 +59,6 @@ export const conversations = pgTable(
 		uniqueIndex("conversations_platform_key_idx").on(
 			t.userId,
 			t.platform,
-			t.workspaceKey,
 			t.externalConversationKey,
 		),
 		index("conversations_user_idx").on(t.userId),


### PR DESCRIPTION
## Summary
- Narrowed `Platform` type from `"cli" | "telegram" | "slack" | "discord"` to `"telegram"` in `packages/db/src/schema/conversations.ts`, aligning it with the core domain type in `packages/core/src/domain/platform.ts`.
- Removed vestigial `workspaceKey` column from the conversations table schema, the unique index, the `AgentService.ensureConversation` signature, and the Telegram utils insert.
- Updated `docs/CHANNELS.md` and `docs/DATA_MODEL.md` to reflect the narrowed type and simplified unique constraint.

Note: Drizzle migration (ALTER TABLE DROP COLUMN, recreate index) must be generated separately.

## Test plan
- [x] `bun install` resolves
- [x] `bun run typecheck` passes (all 13 packages)
- [x] `bun run lint` passes (biome, 290 files, no issues)
- [x] `bun run test` passes (all 8 packages, 170+ tests)
- [x] All existing callers of `ensureConversation` already pass only two arguments — no breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the conversations schema by narrowing `Platform` from a four-value union to `"telegram"` only and dropping the vestigial `workspaceKey` column — bringing the DB schema into alignment with `packages/core/src/domain/platform.ts`. All call sites of `ensureConversation` already passed only two arguments, so the interface change is non-breaking at the TypeScript level.\n\nKey changes:\n- `packages/db/src/schema/conversations.ts`: `Platform = \"telegram\"`, `workspaceKey` column and its participation in the unique index removed.\n- `packages/agent/src/agent.ts`: `workspaceKey?` parameter dropped from `ensureConversation`; `onConflictDoUpdate` target updated to `(userId, platform, externalConversationKey)`.\n- `apps/api/src/telegram/utils.ts`: `workspaceKey: \"\"` dropped from the `/start`-path direct insert (safe; `onConflictDoNothing` is target-agnostic).\n- Docs updated accurately.\n\n**One deployment concern**: `packages/db/drizzle/schema.ts` and the migration files are unchanged — the live DB unique index still covers `(user_id, platform, workspace_key, external_conversation_key)`. PostgreSQL's `ON CONFLICT DO UPDATE` requires the column list to match an existing constraint exactly, so `ensureConversation` in `agent.ts` will throw after this code is deployed but before the migration drops `workspace_key` and recreates the index. The `/start`-path `onConflictDoNothing()` in `utils.ts` is unaffected since it is target-agnostic. The migration must either ship in this PR or be applied before the code is deployed.

<h3>Confidence Score: 3/5</h3>

Not safe to deploy until the Drizzle migration dropping `workspace_key` and recreating the unique index is generated and applied — without it, `ensureConversation` will throw a PostgreSQL constraint-mismatch error on every call.

The TypeScript changes are clean and internally consistent, but the missing migration creates a hard runtime break in the primary message-handling path (`agent.ts` `onConflictDoUpdate` targets a constraint that no longer exists in the source schema but still exists in the DB). This directly affects normal production usage and is not a hypothetical edge case. Score would rise to 4-5 once the migration is included or a deployment ordering guarantee is established.

packages/agent/src/agent.ts (onConflictDoUpdate target mismatch) and the missing migration file under packages/db/drizzle/.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/schema/conversations.ts | Removes `workspaceKey` column and narrows `Platform` type to `"telegram"`; TypeScript-side change is clean but the corresponding Drizzle migration is not included in this PR. |
| packages/agent/src/agent.ts | Removes optional `workspaceKey` param from `ensureConversation` and updates `onConflictDoUpdate` target; will throw a PostgreSQL error at runtime until the DB migration recreates the unique index without `workspace_key`. |
| apps/api/src/telegram/utils.ts | Drops `workspaceKey: ""` from the `/start`-path insert; safe because `onConflictDoNothing()` works with any conflicting constraint and the column's DB default fills in the empty string until migration runs. |
| docs/CHANNELS.md | Docs updated to reflect narrowed platform type, simplified unique key, and updated "add new channel" instructions to mention both schema files. |
| docs/DATA_MODEL.md | Table description updated to remove `workspaceKey` from the unique constraint description; accurate and consistent with the code change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TG as Telegram Webhook
    participant Utils as telegram/utils.ts
    participant Bot as bot.ts / agent-execution.ts
    participant Agent as AgentService
    participant DB as PostgreSQL

    TG->>Utils: /start command
    Utils->>DB: INSERT conversations (userId, platform, externalKey)<br/>ON CONFLICT DO NOTHING
    Note over DB: ✅ Safe pre-migration:<br/>workspace_key defaults to ""

    TG->>Bot: Regular message
    Bot->>Agent: ensureConversation(platform, externalKey)
    Agent->>DB: INSERT conversations<br/>ON CONFLICT (userId, platform, externalKey) DO UPDATE
    Note over DB: ❌ Pre-migration: DB index still includes<br/>workspace_key → constraint mismatch error
    DB-->>Agent: ERROR: no unique constraint matching ON CONFLICT
    Agent-->>Bot: AgentError
```

<sub>Reviews (1): Last reviewed commit: ["Narrow Platform type to &quot;telegram&quot; and r..."](https://github.com/punitarani/amby/commit/a70361cb4482a59dd66b10bbbd7c4c0bc4190cb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26531904)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->