### PR TITLE
Rename AgentService to ConversationRuntime, decompose god service

### DIFF
--- a/apps/api/src/bot.ts
+++ b/apps/api/src/bot.ts
@@ -1,4 +1,4 @@
-import { AgentService, makeAgentServiceLive } from "@amby/agent"
+import { ConversationRuntime, makeConversationRuntimeLive } from "@amby/agent"
 import { createMemoryState } from "@chat-adapter/state-memory"
 import { createTelegramAdapter } from "@chat-adapter/telegram"
 import { Chat } from "chat"
@@ -53,10 +53,10 @@ export function createAmbyBot(runtime: ManagedRuntime.ManagedRuntime<any, any>, 
 			const sendReply = (t: string) => thread.post(t).then(() => {})
 
 			const response = yield* Effect.gen(function* () {
-				const agent = yield* AgentService
+				const agent = yield* ConversationRuntime
 				const conversationId = yield* agent.ensureConversation("telegram", String(chatId))
 				return yield* agent.handleMessage(conversationId, text, { telegram: raw }, sendReply)
-			}).pipe(Effect.provide(makeAgentServiceLive(userId)))
+			}).pipe(Effect.provide(makeConversationRuntimeLive(userId)))
 
 			if (response.userResponse.text.trim()) {
 				yield* Effect.tryPromise(() => thread.post(response.userResponse.text))

--- a/apps/api/src/scripts/test-telegram-flow.ts
+++ b/apps/api/src/scripts/test-telegram-flow.ts
@@ -8,7 +8,7 @@
  * Usage: doppler run -- bun run scripts/test-telegram-flow.ts
  */
 
-import { AgentService, ModelServiceLive, makeAgentServiceLive } from "@amby/agent"
+import { ConversationRuntime, ModelServiceLive, makeConversationRuntimeLive } from "@amby/agent"
 import { AuthServiceLive } from "@amby/auth"
 import { BrowserServiceDisabledLive } from "@amby/browser/local"
 import { SandboxServiceLive, TaskSupervisorLive } from "@amby/computer"
@@ -182,9 +182,9 @@ async function main() {
 	try {
 		maybeConversationId = await runtime.runPromise(
 			Effect.gen(function* () {
-				const agent = yield* AgentService
+				const agent = yield* ConversationRuntime
 				return yield* agent.ensureConversation("telegram", String(SIMULATED_CHAT_ID))
-			}).pipe(Effect.provide(makeAgentServiceLive(userId))),
+			}).pipe(Effect.provide(makeConversationRuntimeLive(userId))),
 		)
 
 		record("Conversation created/found", true)
@@ -204,9 +204,9 @@ async function main() {
 	try {
 		const convId2 = await runtime.runPromise(
 			Effect.gen(function* () {
-				const agent = yield* AgentService
+				const agent = yield* ConversationRuntime
 				return yield* agent.ensureConversation("telegram", String(SIMULATED_CHAT_ID))
-			}).pipe(Effect.provide(makeAgentServiceLive(userId))),
+			}).pipe(Effect.provide(makeConversationRuntimeLive(userId))),
 		)
 
 		if (convId2 === conversationId) {
@@ -223,9 +223,9 @@ async function main() {
 	try {
 		const result = await runtime.runPromise(
 			Effect.gen(function* () {
-				const agent = yield* AgentService
+				const agent = yield* ConversationRuntime
 				return yield* agent.handleMessage(conversationId, "Hello! How are you?")
-			}).pipe(Effect.provide(makeAgentServiceLive(userId))),
+			}).pipe(Effect.provide(makeConversationRuntimeLive(userId))),
 		)
 
 		if (result.userResponse.text.trim().length > 0) {
@@ -244,12 +244,12 @@ async function main() {
 	try {
 		const result = await runtime.runPromise(
 			Effect.gen(function* () {
-				const agent = yield* AgentService
+				const agent = yield* ConversationRuntime
 				return yield* agent.handleMessage(
 					conversationId,
 					"Remember this: my favorite programming language is TypeScript",
 				)
-			}).pipe(Effect.provide(makeAgentServiceLive(userId))),
+			}).pipe(Effect.provide(makeConversationRuntimeLive(userId))),
 		)
 
 		record("Memory save", true)
@@ -264,12 +264,12 @@ async function main() {
 	try {
 		const result = await runtime.runPromise(
 			Effect.gen(function* () {
-				const agent = yield* AgentService
+				const agent = yield* ConversationRuntime
 				return yield* agent.handleMessage(
 					conversationId,
 					"Investigate what day of the week March 25, 2026 falls on",
 				)
-			}).pipe(Effect.provide(makeAgentServiceLive(userId))),
+			}).pipe(Effect.provide(makeConversationRuntimeLive(userId))),
 		)
 
 		record("Research request", true)
@@ -284,9 +284,9 @@ async function main() {
 	try {
 		const result = await runtime.runPromise(
 			Effect.gen(function* () {
-				const agent = yield* AgentService
+				const agent = yield* ConversationRuntime
 				return yield* agent.handleMessage(conversationId, "Set my timezone to America/Los_Angeles")
-			}).pipe(Effect.provide(makeAgentServiceLive(userId))),
+			}).pipe(Effect.provide(makeConversationRuntimeLive(userId))),
 		)
 
 		record("Timezone setting", true)

--- a/apps/api/src/workflows/agent-execution.ts
+++ b/apps/api/src/workflows/agent-execution.ts
@@ -1,5 +1,5 @@
 import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from "cloudflare:workers"
-import { AgentService, makeAgentServiceLive } from "@amby/agent"
+import { ConversationRuntime, makeConversationRuntimeLive } from "@amby/agent"
 import type { WorkerBindings } from "@amby/env/workers"
 import { createTelegramAdapter } from "@chat-adapter/telegram"
 import * as Sentry from "@sentry/cloudflare"
@@ -129,7 +129,7 @@ export class AgentExecutionWorkflow extends WorkflowEntrypoint<
 							const sendReply = (text: string) =>
 								adapter.postMessage(chatIdStr, text).then(() => {})
 							const effect = Effect.gen(function* () {
-								const agent = yield* AgentService
+								const agent = yield* ConversationRuntime
 								const convId =
 									conversationId ?? (yield* agent.ensureConversation("telegram", String(chatId)))
 								conversationId = convId
@@ -146,7 +146,7 @@ export class AgentExecutionWorkflow extends WorkflowEntrypoint<
 									)
 								}
 								return yield* agent.handleMessage(convId, input, undefined, sendReply, onTextDelta)
-							}).pipe(Effect.provide(makeAgentServiceLive(finalUserId)))
+							}).pipe(Effect.provide(makeConversationRuntimeLive(finalUserId)))
 
 							const result = await runtime.runPromise(effect)
 							const finalText = result.userResponse.text

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,12 +1,14 @@
 import { BrowserService } from "@amby/browser"
 import { createComputerTools, createCuaTools, SandboxService, TaskSupervisor } from "@amby/computer"
-import { type Platform, type PluginRegistry, PluginRegistryService } from "@amby/core"
+import { type Platform, PluginRegistryService } from "@amby/core"
 import { DbService, schema } from "@amby/db"
 import { EnvService } from "@amby/env"
 import type { ToolSet } from "ai"
 import { Context, Effect, Layer } from "effect"
 import { prepareConversationContext } from "./context/builder"
 import { type ConversationEngineConfig, handleTurn, type ReplyFn } from "./conversation/engine"
+import { ensureConversation } from "./conversation/ensure"
+import { resolveToolGroupsFromRegistry } from "./conversation/tools"
 import { AgentError } from "./errors"
 import type { ToolGroups } from "./execution/registry"
 import { HIGH_INTELLIGENCE_MODEL_ID, ModelService } from "./models"
@@ -20,8 +22,8 @@ import { createCodexAuthTools } from "./tools/codex-auth"
 import { createTimezoneTools } from "./tools/settings"
 import type { AgentRunResult, StreamPart } from "./types/agent"
 
-export class AgentService extends Context.Tag("AgentService")<
-	AgentService,
+export class ConversationRuntime extends Context.Tag("ConversationRuntime")<
+	ConversationRuntime,
 	{
 		readonly handleMessage: (
 			conversationId: string,
@@ -51,41 +53,12 @@ export class AgentService extends Context.Tag("AgentService")<
 	}
 >() {}
 
-/**
- * Resolve tool groups from the plugin registry.
- *
- * Each tool provider is mapped to its declared group. The agent's
- * specialist registry uses these groups to select which tools are
- * visible to each specialist.
- */
-async function resolveToolGroupsFromRegistry(
-	registry: PluginRegistry,
-	userId: string,
-	conversationId: string,
-	threadId: string,
-): Promise<ToolGroups> {
-	const groups: ToolGroups = {}
-	const context = { userId, conversationId, threadId }
-	for (const provider of registry.toolProviders) {
-		try {
-			const tools = await provider.getTools(context)
-			if (tools && Object.keys(tools).length > 0) {
-				const group = provider.group as keyof ToolGroups
-				groups[group] = { ...(groups[group] ?? {}), ...tools } as ToolSet
-			}
-		} catch (err) {
-			console.warn(
-				`[agent] Tool provider "${provider.id}" (group: ${provider.group}) failed, skipping:`,
-				err instanceof Error ? err.message : String(err),
-			)
-		}
-	}
-	return groups
-}
+/** @deprecated Use `ConversationRuntime` instead. */
+export const AgentService = ConversationRuntime
 
-export const makeAgentServiceLive = (userId: string) =>
+export const makeConversationRuntimeLive = (userId: string) =>
 	Layer.effect(
-		AgentService,
+		ConversationRuntime,
 		Effect.gen(function* () {
 			const { db, query } = yield* DbService
 			const models = yield* ModelService
@@ -204,39 +177,7 @@ export const makeAgentServiceLive = (userId: string) =>
 					}),
 
 				ensureConversation: (platform, externalConversationKey, workspaceKey) =>
-					query((database) =>
-						database
-							.insert(schema.conversations)
-							.values({
-								userId,
-								platform,
-								externalConversationKey,
-								workspaceKey: workspaceKey ?? "",
-							})
-							.onConflictDoUpdate({
-								target: [
-									schema.conversations.userId,
-									schema.conversations.platform,
-									schema.conversations.workspaceKey,
-									schema.conversations.externalConversationKey,
-								],
-								set: { updatedAt: new Date() },
-							})
-							.returning({ id: schema.conversations.id }),
-					).pipe(
-						Effect.map((rows) => {
-							const row = rows[0]
-							if (!row) throw new Error("Failed to ensure conversation")
-							return row.id
-						}),
-						Effect.mapError(
-							(cause) =>
-								new AgentError({
-									message: cause instanceof Error ? cause.message : "Failed to ensure conversation",
-									cause,
-								}),
-						),
-					),
+					ensureConversation(query, userId, platform, externalConversationKey, workspaceKey),
 
 				shutdown: () =>
 					Effect.gen(function* () {
@@ -256,3 +197,6 @@ export const makeAgentServiceLive = (userId: string) =>
 			}
 		}),
 	)
+
+/** @deprecated Use `makeConversationRuntimeLive` instead. */
+export const makeAgentServiceLive = makeConversationRuntimeLive

--- a/packages/agent/src/conversation/engine.ts
+++ b/packages/agent/src/conversation/engine.ts
@@ -207,7 +207,7 @@ export interface TurnRequest {
 
 /**
  * ConversationEngine handles a single conversation turn.
- * This is the extracted core from the old AgentService.runRequest.
+ * This is the extracted core from ConversationRuntime.
  */
 export function handleTurn(
 	config: ConversationEngineConfig,

--- a/packages/agent/src/conversation/ensure.ts
+++ b/packages/agent/src/conversation/ensure.ts
@@ -1,0 +1,53 @@
+import type { Platform } from "@amby/core"
+import { type Database, schema } from "@amby/db"
+import { Effect } from "effect"
+import { AgentError } from "../errors"
+
+/**
+ * Upsert a conversation for the given user + platform + external key.
+ *
+ * Returns the conversation ID. If a matching conversation already exists
+ * (same user, platform, workspace, and external key), its `updatedAt`
+ * timestamp is bumped and the existing ID is returned.
+ */
+export function ensureConversation(
+	query: <T>(fn: (db: Database) => Promise<T>) => Effect.Effect<T, unknown>,
+	userId: string,
+	platform: Platform,
+	externalConversationKey: string,
+	workspaceKey?: string,
+): Effect.Effect<string, AgentError> {
+	return query((database) =>
+		database
+			.insert(schema.conversations)
+			.values({
+				userId,
+				platform,
+				externalConversationKey,
+				workspaceKey: workspaceKey ?? "",
+			})
+			.onConflictDoUpdate({
+				target: [
+					schema.conversations.userId,
+					schema.conversations.platform,
+					schema.conversations.workspaceKey,
+					schema.conversations.externalConversationKey,
+				],
+				set: { updatedAt: new Date() },
+			})
+			.returning({ id: schema.conversations.id }),
+	).pipe(
+		Effect.map((rows) => {
+			const row = rows[0]
+			if (!row) throw new Error("Failed to ensure conversation")
+			return row.id
+		}),
+		Effect.mapError(
+			(cause) =>
+				new AgentError({
+					message: cause instanceof Error ? cause.message : "Failed to ensure conversation",
+					cause,
+				}),
+		),
+	)
+}

--- a/packages/agent/src/conversation/tools.ts
+++ b/packages/agent/src/conversation/tools.ts
@@ -1,0 +1,35 @@
+import type { PluginRegistry } from "@amby/core"
+import type { ToolSet } from "ai"
+import type { ToolGroups } from "../execution/registry"
+
+/**
+ * Resolve tool groups from the plugin registry.
+ *
+ * Each tool provider is mapped to its declared group. The agent's
+ * specialist registry uses these groups to select which tools are
+ * visible to each specialist.
+ */
+export async function resolveToolGroupsFromRegistry(
+	registry: PluginRegistry,
+	userId: string,
+	conversationId: string,
+	threadId: string,
+): Promise<ToolGroups> {
+	const groups: ToolGroups = {}
+	const context = { userId, conversationId, threadId }
+	for (const provider of registry.toolProviders) {
+		try {
+			const tools = await provider.getTools(context)
+			if (tools && Object.keys(tools).length > 0) {
+				const group = provider.group as keyof ToolGroups
+				groups[group] = { ...(groups[group] ?? {}), ...tools } as ToolSet
+			}
+		} catch (err) {
+			console.warn(
+				`[agent] Tool provider "${provider.id}" (group: ${provider.group}) failed, skipping:`,
+				err instanceof Error ? err.message : String(err),
+			)
+		}
+	}
+	return groups
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,8 @@ export {
 	handleTurn,
 	type TurnRequest,
 } from "./conversation/engine"
+export { ensureConversation } from "./conversation/ensure"
+export { resolveToolGroupsFromRegistry } from "./conversation/tools"
 export * from "./errors"
 export * from "./models"
 export * from "./router"


### PR DESCRIPTION
## Summary
- Renames `AgentService` to `ConversationRuntime` (Effect tag: `"ConversationRuntime"`) to reflect its actual role as the conversation turn orchestrator
- Extracts `ensureConversation` into `packages/agent/src/conversation/ensure.ts` as a standalone function (simple DB upsert, no service dependency)
- Extracts `resolveToolGroupsFromRegistry` into `packages/agent/src/conversation/tools.ts` (plugin registry tool resolution)
- Updates all 3 caller sites (`bot.ts`, `agent-execution.ts`, `test-telegram-flow.ts`) to use the new names
- Preserves deprecated `AgentService` and `makeAgentServiceLive` aliases for backwards compatibility

## Test plan
- [x] `bun run typecheck` -- all 13 packages pass (agent + api were cache misses, actually re-checked)
- [x] `bun run lint` -- biome check passes clean
- [x] `bun run test` -- no new test failures (2 pre-existing module resolution failures confirmed on base branch)
- [x] Verified behavioral equivalence: no functional changes, only naming and internal decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `AgentService` Effect tag to `ConversationRuntime` (with a better-reflecting tag string `"ConversationRuntime"`) and decomposes the god-service by extracting `ensureConversation` and `resolveToolGroupsFromRegistry` into standalone modules under `packages/agent/src/conversation/`. All three caller sites are updated and deprecated const aliases (`AgentService`, `makeAgentServiceLive`) are preserved for backwards compatibility.

- **Rename is clean and complete** — all 3 caller sites updated, deprecated aliases added, Effect tag identifier updated.
- **`ensure.ts`**: the extracted `ensureConversation` carries over a pre-existing `throw`-inside-`Effect.map` pattern. In Effect-ts this produces a `Cause.Die` defect rather than a typed `AgentError`, meaning the `Effect.mapError` on the next line does not cover the `rows[0]` undefined case. Worth fixing now that the function is standalone and easier to reason about.
- **Public surface expansion** — `ensureConversation` and `resolveToolGroupsFromRegistry` are now re-exported from `index.ts`. These were previously private implementation details; intentional per the PR description, but consumers should be aware they are now part of the public API.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely structural refactoring with backwards-compatible aliases; one pre-existing defect in `ensure.ts` worth fixing opportunistically.

All functional logic is unchanged, the deprecated aliases ensure no breakage for any unconverted callers, and the PR description confirms typecheck/lint/test pass. A single P1 observation (throw-inside-Effect.map defect in `ensure.ts`) was pre-existing in `agent.ts` but is now easier to fix; it doesn't block merge but is worth addressing in a follow-up.

packages/agent/src/conversation/ensure.ts — carries over the throw-inside-Effect.map defect from the original implementation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/agent.ts | Renames `AgentService` class to `ConversationRuntime`, adds deprecated const aliases for the old names, and delegates `ensureConversation` / `resolveToolGroupsFromRegistry` to the new standalone modules — no logic changes. |
| packages/agent/src/conversation/ensure.ts | New standalone `ensureConversation` function extracted from `agent.ts`; faithful copy of original logic but carries over the `throw`-inside-`Effect.map` defect pattern that bypasses typed error handling. |
| packages/agent/src/conversation/tools.ts | Exact move of `resolveToolGroupsFromRegistry` from `agent.ts` into its own module — no logic changes. |
| packages/agent/src/index.ts | Adds re-exports for `ensureConversation` and `resolveToolGroupsFromRegistry` from the new sub-modules. |
| apps/api/src/bot.ts | Caller site updated to use `ConversationRuntime` and `makeConversationRuntimeLive` — mechanical rename, no logic changes. |
| apps/api/src/workflows/agent-execution.ts | Caller site updated to use `ConversationRuntime` and `makeConversationRuntimeLive` — mechanical rename, no logic changes. |
| apps/api/src/scripts/test-telegram-flow.ts | Test script caller site updated to use new names — mechanical rename across 6 call sites, no logic changes. |
| packages/agent/src/conversation/engine.ts | Doc-comment updated to reference `ConversationRuntime` instead of `AgentService` — documentation-only change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (god service)"]
        A["agent.ts\nAgentService\n─────────────\nensureConversation()\nresolveToolGroupsFromRegistry()\nhandleMessage()\nhandleBatchedMessages()\nstreamMessage()\nshutdown()"]
    end

    subgraph After["After (decomposed)"]
        B["agent.ts\nConversationRuntime\n─────────────\nhandleMessage()\nhandleBatchedMessages()\nstreamMessage()\nshutdown()"]
        C["conversation/ensure.ts\nensureConversation()"]
        D["conversation/tools.ts\nresolveToolGroupsFromRegistry()"]
        E["deprecated aliases\nAgentService = ConversationRuntime\nmakeAgentServiceLive = makeConversationRuntimeLive"]
    end

    B -->|delegates| C
    B -->|delegates| D
    B --- E

    F["Callers\nbot.ts\nagent-execution.ts\ntest-telegram-flow.ts"] -->|yield* ConversationRuntime| B
    G["index.ts exports"] -->|re-exports| B
    G -->|re-exports| C
    G -->|re-exports| D
```

<sub>Reviews (1): Last reviewed commit: ["Rename AgentService to ConversationRunti..."](https://github.com/punitarani/amby/commit/64248571f51dc2a2f31bf5b3b0ea8cbf81d19a87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26531925)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->